### PR TITLE
Refactoring/runtime folders

### DIFF
--- a/samples/MBrace.Azure.CloudService.WorkerRole/WorkerRole.cs
+++ b/samples/MBrace.Azure.CloudService.WorkerRole/WorkerRole.cs
@@ -40,8 +40,8 @@ namespace MBrace.Azure.CloudService.WorkerRole
             _config = Configuration.Default
                         .WithStorageConnectionString(CloudConfigurationManager.GetSetting("MBrace.StorageConnectionString"))
                         .WithServiceBusConnectionString(CloudConfigurationManager.GetSetting("MBrace.ServiceBusConnectionString"));
-
-            _svc = new Service(_config);
+            var serviceName = RoleEnvironment.CurrentRoleInstance.Id;
+            _svc = new Service(_config, serviceId : serviceName);
             _svc.AttachLogger(new CustomLogger(s => Trace.WriteLine(String.Format("{0} : {1}", DateTime.UtcNow,s))));
 
             RoleEnvironment.Changed += RoleEnvironment_Changed;

--- a/samples/MBrace.Azure.Runtime.Standalone/Program.fs
+++ b/samples/MBrace.Azure.Runtime.Standalone/Program.fs
@@ -1,5 +1,6 @@
 ﻿module internal MBrace.Azure.Runtime.Standalone.Program 
     open System
+    open MBrace.Azure
     open MBrace.Azure.Runtime
     open MBrace.Azure.Runtime.Common
     open System.Diagnostics

--- a/samples/MBrace.Azure.Runtime.Standalone/RuntimeExtensions.fs
+++ b/samples/MBrace.Azure.Runtime.Standalone/RuntimeExtensions.fs
@@ -5,6 +5,7 @@ open MBrace.Azure.Client
 open System.Diagnostics
 open System.IO
 open MBrace.Continuation
+open MBrace.Azure.Runtime
 
 /// BASE64 serialized argument parsing schema
 
@@ -28,7 +29,7 @@ type private Helpers () =
     static member val exe = None with get, set
 
     static member InitWorkers (config : Argument.Config) (count : int) exe =
-        MBrace.Azure.Runtime.Configuration.Activate(config.Configuration)
+        do Async.RunSync(Configuration.ActivateAsync(config.Configuration.WithAppendedId))
         if count < 1 then invalidArg "workerCount" "must be positive."  
         let args = Argument.ofConfiguration config 
         let psi = new ProcessStartInfo(exe, args)

--- a/samples/MBrace.Azure.Runtime.Standalone/RuntimeExtensions.fs
+++ b/samples/MBrace.Azure.Runtime.Standalone/RuntimeExtensions.fs
@@ -1,5 +1,6 @@
 ﻿namespace MBrace.Azure.Runtime.Standalone
 
+open MBrace.Azure
 open MBrace.Azure.Client
 open System.Diagnostics
 open System.IO

--- a/src/MBrace.Azure.Client/Client.fs
+++ b/src/MBrace.Azure.Client/Client.fs
@@ -304,27 +304,27 @@
         /// Delete runtime records for given process.
         /// </summary>
         /// <param name="pid">Process Id.</param>
-        /// <param name="fullClear">Delete all records and blobs used by this process. Defaults to false.</param>
+        /// <param name="fullClear">Delete all records and blobs used by this process. Defaults to true.</param>
         /// <param name="force">Force deletion on not completed processes.</param>
         member __.ClearProcessAsync(pid, ?fullClear, ?force : bool) = 
             let force = defaultArg force false
-            let fullClear = defaultArg fullClear false
+            let fullClear = defaultArg fullClear true
             pmon.ClearProcess(pid, full = fullClear, force = force)
         
         /// <summary>
         /// Delete runtime records for all processes.
         /// </summary>
-        /// <param name="fullClear">Delete all records and blobs used by this process.Defaults to false.</param>
+        /// <param name="fullClear">Delete all records and blobs used by this process.Defaults to true.</param>
         /// <param name="force">Force deletion on not completed processes.</param>
         member __.ClearAllProcesses(?fullClear, ?force) = __.ClearAllProcessesAsync(?fullClear = fullClear, ?force = force) |> Async.RunSync
         /// <summary>
         /// Delete runtime records for all processes.
         /// </summary>
-        /// <param name="fullClear">Delete all records and blobs used by this process.Defaults to false.</param>
+        /// <param name="fullClear">Delete all records and blobs used by this process.Defaults to true.</param>
         /// <param name="force">Force deletion on not completed processes.</param>
         member __.ClearAllProcessesAsync(?fullClear, ?force : bool) = 
             let force = defaultArg force false
-            let fullClear = defaultArg fullClear false
+            let fullClear = defaultArg fullClear true
             pmon.ClearAllProcesses(force = force, full = fullClear)
 
         /// <summary>

--- a/src/MBrace.Azure.Client/Client.fs
+++ b/src/MBrace.Azure.Client/Client.fs
@@ -337,7 +337,7 @@
 
                 clientLogger.Logf "Calling Reset."
                 storageLogger.Stop()
-                let cl = new Common.ConsoleLogger() // Using client (storage) logger will throw exc.
+                let cl = new ConsoleLogger() // Using client (storage) logger will throw exc.
                 let! step1 =
                     if clearAllProcesses then
                         cl.Logf "Calling ClearAllProcesses."

--- a/src/MBrace.Azure.Client/Client.fs
+++ b/src/MBrace.Azure.Client/Client.fs
@@ -297,29 +297,35 @@
         /// Delete runtime records for given process.
         /// </summary>
         /// <param name="pid">Process Id.</param>
+        /// <param name="fullClear">Delete all records and blobs used by this process.</param>
         /// <param name="force">Force deletion on not completed processes.</param>
-        member __.ClearProcess(pid, ?force) = __.ClearProcessAsync(pid, ?force = force) |> Async.RunSync
+        member __.ClearProcess(pid, ?fullClear, ?force) = __.ClearProcessAsync(pid, ?fullClear = fullClear, ?force = force) |> Async.RunSync
         /// <summary>
         /// Delete runtime records for given process.
         /// </summary>
         /// <param name="pid">Process Id.</param>
+        /// <param name="fullClear">Delete all records and blobs used by this process. Defaults to false.</param>
         /// <param name="force">Force deletion on not completed processes.</param>
-        member __.ClearProcessAsync(pid, ?force : bool) = 
+        member __.ClearProcessAsync(pid, ?fullClear, ?force : bool) = 
             let force = defaultArg force false
-            pmon.ClearProcess(pid, force = force)
+            let fullClear = defaultArg fullClear false
+            pmon.ClearProcess(pid, full = fullClear, force = force)
         
         /// <summary>
         /// Delete runtime records for all processes.
         /// </summary>
+        /// <param name="fullClear">Delete all records and blobs used by this process.Defaults to false.</param>
         /// <param name="force">Force deletion on not completed processes.</param>
-        member __.ClearAllProcesses(?force) = __.ClearAllProcessesAsync(?force = force) |> Async.RunSync
+        member __.ClearAllProcesses(?fullClear, ?force) = __.ClearAllProcessesAsync(?fullClear = fullClear, ?force = force) |> Async.RunSync
         /// <summary>
         /// Delete runtime records for all processes.
         /// </summary>
+        /// <param name="fullClear">Delete all records and blobs used by this process.Defaults to false.</param>
         /// <param name="force">Force deletion on not completed processes.</param>
-        member __.ClearAllProcessesAsync(?force : bool) = 
+        member __.ClearAllProcessesAsync(?fullClear, ?force : bool) = 
             let force = defaultArg force false
-            pmon.ClearAllProcesses(force = force)
+            let fullClear = defaultArg fullClear false
+            pmon.ClearAllProcesses(force = force, full = fullClear)
 
         /// <summary>
         /// Delete and re-activate runtime state.
@@ -329,7 +335,7 @@
         /// <param name="deleteState">Delete runtime container and table. Defaults to true.</param>
         /// <param name="deleteLogs">Delete runtime logs table. Defaults to true.</param>
         /// <param name="deleteUserData">Delete Configuration.UserData container and table. Defaults to true.</param>
-        /// <param name="reactivate">Reactivate configuration.</param>
+        /// <param name="reactivate">Reactivate configuration. Defaults to true.</param>
         [<CompilerMessage("Using 'Reset' may cause unexpected behavior in clients and workers.", 445)>]
         member __.Reset(?deleteQueue, ?deleteState, ?deleteLogs, ?deleteUserData, ?reactivate) =
             async {

--- a/src/MBrace.Azure.Client/Client.fs
+++ b/src/MBrace.Azure.Client/Client.fs
@@ -54,7 +54,7 @@
         /// Creates a fresh CloudCancellationTokenSource for this runtime.
         /// </summary>
         member __.CreateCancellationTokenSource () =
-            state.ResourceFactory.RequestCancellationTokenSource() 
+            state.ResourceFactory.RequestCancellationTokenSource(guid()) 
             |> Async.RunSync :> ICloudCancellationTokenSource
 
         /// <summary>

--- a/src/MBrace.Azure.Client/Client.fs
+++ b/src/MBrace.Azure.Client/Client.fs
@@ -297,7 +297,7 @@
         /// Delete runtime records for given process.
         /// </summary>
         /// <param name="pid">Process Id.</param>
-        /// <param name="fullClear">Delete all records and blobs used by this process.</param>
+        /// <param name="fullClear">Delete all records and blobs used by this process. Defaults to true.</param>
         /// <param name="force">Force deletion on not completed processes.</param>
         member __.ClearProcess(pid, ?fullClear, ?force) = __.ClearProcessAsync(pid, ?fullClear = fullClear, ?force = force) |> Async.RunSync
         /// <summary>

--- a/src/MBrace.Azure.Client/Process.fs
+++ b/src/MBrace.Azure.Client/Process.fs
@@ -24,7 +24,7 @@ type Process internal (config, pid : string, ty : Type, pmon : ProcessManager) =
                     stopf = fun _ -> false)
 
     let logger = new ProcessLogger(config, pid)
-    let dcts = lazy DistributedCancellationTokenSource.FromPath(config, proc.Value.CancellationUri)
+    let dcts = lazy DistributedCancellationTokenSource.FromPath(config, proc.Value.Id, proc.Value.CancellationUri)
 
     member internal __.ProcessEntity = proc
     member internal __.DistributedCancellationTokenSource = dcts.Value

--- a/src/MBrace.Azure.Client/Process.fs
+++ b/src/MBrace.Azure.Client/Process.fs
@@ -21,7 +21,10 @@ type Process internal (config, pid : string, ty : Type, pmon : ProcessManager) =
     let proc = 
         new Live<_>((fun () -> pmon.GetProcess(pid)), initial = Choice2Of2(exn ("Process not initialized")), 
                     keepLast = true, interval = 500, 
-                    stopf = fun _ -> false)
+                    stopf = 
+                        function 
+                        | Choice1Of2 p when p.Completed -> true
+                        | _ -> false )
 
     let logger = new ProcessLogger(config, pid)
     let dcts = lazy DistributedCancellationTokenSource.FromPath(config, proc.Value.Id, proc.Value.CancellationUri)

--- a/src/MBrace.Azure.Client/Process.fs
+++ b/src/MBrace.Azure.Client/Process.fs
@@ -12,6 +12,7 @@ open System
 open System.IO
 open System.Threading
 open System.Reflection
+open MBrace.Azure
 
 [<AutoSerializable(false); AbstractClass>]
 /// Represents a cloud process.
@@ -22,8 +23,8 @@ type Process internal (config, pid : string, ty : Type, pmon : ProcessManager) =
                     keepLast = true, interval = 500, 
                     stopf = fun _ -> false)
 
-    let logger = new ProcessLogger(config, Storage.processIdToStorageId pid, pid)
-    let dcts = lazy DistributedCancellationTokenSource.FromUri(config, new Uri(proc.Value.CancellationUri))
+    let logger = new ProcessLogger(config, pid)
+    let dcts = lazy DistributedCancellationTokenSource.FromPath(config, proc.Value.CancellationUri)
 
     member internal __.ProcessEntity = proc
     member internal __.DistributedCancellationTokenSource = dcts.Value
@@ -100,7 +101,7 @@ type Process<'T> internal (config, pid : string, pmon : ProcessManager) =
     override __.AwaitResultBoxed () : obj =__.AwaitResultBoxedAsync() |> Async.RunSync 
     override __.AwaitResultBoxedAsync () : Async<obj> =
         async {
-            let rc : ResultCell<'T> = ResultCell.FromUri<_>(config, new Uri(__.ProcessEntity.Value.ResultUri))
+            let rc : ResultCell<'T> = ResultCell.FromPath(config, __.ProcessEntity.Value.ResultUri)
             let! r = rc.AwaitResult()
             return r.Value :> obj
         }
@@ -110,7 +111,7 @@ type Process<'T> internal (config, pid : string, pmon : ProcessManager) =
     /// Asynchronously waits for the process result.
     member __.AwaitResultAsync() : Async<'T> = 
         async {
-            let rc : ResultCell<'T> = ResultCell.FromUri<_>(config, new Uri(__.ProcessEntity.Value.ResultUri))
+            let rc : ResultCell<'T> = ResultCell.FromPath(config, __.ProcessEntity.Value.ResultUri)
             let! r = rc.AwaitResult()
             return r.Value
         }

--- a/src/MBrace.Azure.Client/StoreClient.fs
+++ b/src/MBrace.Azure.Client/StoreClient.fs
@@ -5,6 +5,7 @@ open MBrace.Continuation
 open MBrace.Store
 open MBrace.Runtime.Store
 open MBrace.Azure.Store
+open MBrace.Azure
 
 [<Sealed>]
 type internal StoreClient private () =
@@ -19,8 +20,8 @@ type internal StoreClient private () =
                 override __.ComputeSize(value : 'T) = Configuration.Pickler.ComputeSize(value) } :> ICloudAtomProvider
         let channelProvider = ChannelProvider.Create(config.ServiceBusConnectionString, Configuration.Serializer)
     
-        let defaultStoreContainer = config.DefaultTableOrContainer
-        let defaultAtomContainer = config.DefaultTableOrContainer
+        let defaultStoreContainer = config.UserDataContainer
+        let defaultAtomContainer = config.UserDataTable
         let defaultChannelContainer = ""
 
         let resources = 

--- a/src/MBrace.Azure.Client/StoreClient.fs
+++ b/src/MBrace.Azure.Client/StoreClient.fs
@@ -11,9 +11,6 @@ open MBrace.Azure
 type internal StoreClient private () =
     
     static member CreateDefault(config : Configuration) : ResourceRegistry * MBrace.Client.StoreClient =
-
-        Configuration.Activate(config)
-
         let storeProvider = BlobStore.Create(config.StorageConnectionString) :> ICloudFileStore
         let atomProvider = 
             { new AtomProvider(config.StorageConnectionString, Configuration.Serializer) with

--- a/src/MBrace.Azure.Runtime.Common/Combinators.fs
+++ b/src/MBrace.Azure.Runtime.Common/Combinators.fs
@@ -35,10 +35,10 @@ let Parallel (state : RuntimeState) (psInfo : ProcessInfo) (jobId : string) depe
         | Choice1Of2 computations ->
             // request runtime resources required for distribution coordination
             let currentCts = ctx.CancellationToken :?> DistributedCancellationTokenSource
-            let! childCts = state.ResourceFactory.RequestCancellationTokenSource(parent = currentCts, metadata = jobId)
+            let! childCts = state.ResourceFactory.RequestCancellationTokenSource(psInfo.Id, parent = currentCts, metadata = jobId)
             
-            let! resultAggregator = state.ResourceFactory.RequestResultAggregator<'T>(computations.Length)
-            let! cancellationLatch = state.ResourceFactory.RequestCounter(0)
+            let! resultAggregator = state.ResourceFactory.RequestResultAggregator<'T>(computations.Length, psInfo.Id)
+            let! cancellationLatch = state.ResourceFactory.RequestCounter(0, psInfo.Id)
 
             let onSuccess i ctx (t : 'T) = 
                 async {
@@ -94,10 +94,10 @@ let Choice (state : RuntimeState) (psInfo : ProcessInfo) (jobId : string) depend
             // request runtime resources required for distribution coordination
             let n = computations.Length // avoid capturing computation array in cont closures
             let currentCts = ctx.CancellationToken :?> DistributedCancellationTokenSource
-            let! childCts = state.ResourceFactory.RequestCancellationTokenSource(parent = currentCts, metadata = jobId)
+            let! childCts = state.ResourceFactory.RequestCancellationTokenSource(psInfo.Id, parent = currentCts, metadata = jobId)
 
-            let! completionLatch = state.ResourceFactory.RequestCounter(0)
-            let! cancellationLatch = state.ResourceFactory.RequestCounter(0)
+            let! completionLatch = state.ResourceFactory.RequestCounter(0, psInfo.Id)
+            let! cancellationLatch = state.ResourceFactory.RequestCounter(0, psInfo.Id)
 
             let onSuccess ctx (topt : 'T option) =
                 async {

--- a/src/MBrace.Azure.Runtime.Common/Config.fs
+++ b/src/MBrace.Azure.Runtime.Common/Config.fs
@@ -214,7 +214,7 @@ module Configuration =
     /// Default ISerializer
     let Serializer = init (); new FsPicklerBinaryStoreSerializer() :> ISerializer
 
-    /// Initialize Vagabond.
+    /// Vagabond initialization.
     let Initialize () = init ()
 
     /// Activates the given configuration.
@@ -232,9 +232,6 @@ module Configuration =
 
     let GetIgnoredAssemblies() : seq<Assembly> =
         ignoredAssemblies :> _
-
-    /// Activates the given configuration.
-    let Activate(config : Configuration) = Async.RunSynchronously(ActivateAsync(config))
 
     /// Warning : Deletes all queues, tables and containers described in the given configuration.
     /// Does not delete process created resources.

--- a/src/MBrace.Azure.Runtime.Common/Config.fs
+++ b/src/MBrace.Azure.Runtime.Common/Config.fs
@@ -59,13 +59,14 @@ type Configuration =
         { Id                         = 0us
           StorageConnectionString    = "your connection string"
           ServiceBusConnectionString = "your connection string"
-          RuntimeQueue               = "mbraceruntimequeue"
-          RuntimeTopic               = "mbraceruntimetopic"
+          // See Azure/ServiceBus name limits
+          RuntimeQueue               = "MBraceQueue"
+          RuntimeTopic               = "MBraceTopic"
           RuntimeContainer           = "mbraceruntimedata"
-          RuntimeTable               = "mbraceruntimedata"
-          RuntimeLogsTable           = "mbraceruntimelogs"
+          RuntimeTable               = "MBraceRuntimeData"
+          RuntimeLogsTable           = "MBraceRuntimeLogs"
           UserDataContainer          = "mbraceuserdata"
-          UserDataTable              = "mbraceuserdata" }
+          UserDataTable              = "MBraceUserData" }
 
 
     /// Append Configuration.Id on all values.

--- a/src/MBrace.Azure.Runtime.Common/Config.fs
+++ b/src/MBrace.Azure.Runtime.Common/Config.fs
@@ -9,7 +9,7 @@ open System.Text
 type ConfigurationId = 
     private 
       { /// Runtime identifier.
-        Id : uint32
+        Id : uint16
         /// Azure storage connection string hash.
         StorageConnectionStringHash : byte []
         /// Service Bus connection string hash.
@@ -33,7 +33,7 @@ type ConfigurationId =
 /// Azure specific Runtime Configuration.
 type Configuration = 
     { /// Runtime identifier.
-      Id : uint32
+      Id : uint16
       /// Azure storage connection string.
       StorageConnectionString : string
       /// Service Bus connection string.
@@ -56,7 +56,7 @@ type Configuration =
 
     /// Returns an Azure Configuration with the default values.
     static member Default = 
-        { Id                         = 0u
+        { Id                         = 0us
           StorageConnectionString    = "your connection string"
           ServiceBusConnectionString = "your connection string"
           RuntimeQueue               = "mbraceruntimequeue"
@@ -70,7 +70,7 @@ type Configuration =
 
     /// Append Configuration.Id on all values.
     member this.WithAppendedId =
-        let withId s = sprintf "%s%10d" s this.Id
+        let withId s = sprintf "%s%05d" s this.Id
         { this with
             RuntimeQueue = withId this.RuntimeQueue
             RuntimeTopic = withId this.RuntimeTopic

--- a/src/MBrace.Azure.Runtime.Common/Config.fs
+++ b/src/MBrace.Azure.Runtime.Common/Config.fs
@@ -31,7 +31,6 @@ type ConfigurationId =
 
 
 /// Azure specific Runtime Configuration.
-[<AutoSerializable(false)>]
 type Configuration = 
     { /// Runtime identifier.
       Id : uint32

--- a/src/MBrace.Azure.Runtime.Common/Job.fs
+++ b/src/MBrace.Azure.Runtime.Common/Job.fs
@@ -255,7 +255,7 @@ with
     /// Schedules a cloud workflow as an ICloudTask.
     member internal rt.StartAsTask(psInfo : ProcessInfo, dependencies, cts, fp, wf : Cloud<'T>, jobType, parentJobId) : Async<ICloudTask<'T>> = async {
         let jobId = guid()
-        let! resultCell = rt.ResourceFactory.RequestResultCell<'T>(jobId)
+        let! resultCell = rt.ResourceFactory.RequestResultCell<'T>(jobId, psInfo.Id)
         let setResult ctx r = 
             async {
                 do! resultCell.SetResult r
@@ -275,14 +275,14 @@ with
         let jobId = guid ()
         let! cts = 
             match ct with
-            | None -> rt.ResourceFactory.RequestCancellationTokenSource(metadata = jobId)
+            | None -> rt.ResourceFactory.RequestCancellationTokenSource(psInfo.Id, metadata = jobId)
             | Some ct -> async { return ct :?> DistributedCancellationTokenSource }
 
-        let! resultCell = rt.ResourceFactory.RequestResultCell<'T>(jobId)
+        let! resultCell = rt.ResourceFactory.RequestResultCell<'T>(jobId, psInfo.Id)
 
         let! _ = rt.ProcessMonitor
                    .CreateRecord(psInfo.Id, psInfo.Name, typeof<'T>, dependencies,
-                                   string cts.Path, 
+                                   string cts.RowKey, 
                                    string resultCell.Path)
 
         let setResult ctx r = 

--- a/src/MBrace.Azure.Runtime.Common/Job.fs
+++ b/src/MBrace.Azure.Runtime.Common/Job.fs
@@ -223,7 +223,7 @@ with
             let jobp = VagabondRegistry.Instance.Pickler.PickleTyped job
             jobs.[i] <- { PickledJob = jobp; Dependencies = dependencies }, affinity
         async {
-            do! rt.JobQueue.EnqueueBatch<JobItem>(jobs)
+            do! rt.JobQueue.EnqueueBatch<JobItem>(jobs, pid = psInfo.Id)
             do! rt.ProcessMonitor.IncreaseTotalJobs(psInfo.Id, jobs.Length)
         }
 
@@ -248,7 +248,7 @@ with
         let jobp = VagabondRegistry.Instance.Pickler.PickleTyped job
         let jobItem = { PickledJob = jobp; Dependencies = dependencies }
         async {
-            do! rt.JobQueue.Enqueue<JobItem>(jobItem, ?affinity = affinity)
+            do! rt.JobQueue.Enqueue<JobItem>(jobItem, ?affinity = affinity, pid = psInfo.Id)
             do! rt.ProcessMonitor.IncreaseTotalJobs(psInfo.Id)
         }
 

--- a/src/MBrace.Azure.Runtime.Common/Records/Logging.fs
+++ b/src/MBrace.Azure.Runtime.Common/Records/Logging.fs
@@ -2,7 +2,7 @@
 
 open System
 open Microsoft.WindowsAzure.Storage.Table
-
+open MBrace.Azure
 open MBrace.Continuation
 open System.Collections.Concurrent
 open MBrace.Runtime
@@ -39,8 +39,9 @@ type LoggerCombiner (loggers) =
     
   
 
-type StorageLogger(config, table : string, loggerType : LoggerType) =
+type StorageLogger(config : ConfigurationId, loggerType : LoggerType) =
     let maxWaitTime = 5000
+    let table = config.RuntimeLogsTable
     let logs = ResizeArray<LogRecord>()
     let timeToRK (time : DateTimeOffset) = sprintf "%020d" time.Ticks 
     let mutable running = true
@@ -138,9 +139,9 @@ type CustomLogger (f : Action<string>) =
             f.Invoke(entry)
  
  // TODO : Remove?       
-type ProcessLogger(config, table : string, pid : string) =
+type ProcessLogger(config : ConfigurationId, pid : string) =
     let loggerType = ProcessLog pid
-
+    let table = config.UserDataTable
     let timeToRK (time : DateTimeOffset) = sprintf "%020d" time.Ticks 
 
     interface ICloudLogger with

--- a/src/MBrace.Azure.Runtime.Common/Records/Logging.fs
+++ b/src/MBrace.Azure.Runtime.Common/Records/Logging.fs
@@ -113,30 +113,6 @@ type StorageLogger(config : ConfigurationId, loggerType : LoggerType) =
             | Some f -> query.Where(f)
         Table.query config table query
 
-type NullLogger () =
-    interface ICloudLogger with
-        member __.Log(_: string): unit = ()
-        
-type ConsoleLogger () =
-    let format = "ddMMyyyy HH:mm:ss.fff zzz" // 31012015 15:42:50.404 +02:00
-    let prettyPrint (message : string) =
-        let offset = format.Length + 4
-        let space = new String(' ', offset)
-        let sb = new System.Text.StringBuilder()
-        let mutable first = true
-        for line in message.Split('\n') do
-            if first then first <- false else sb.Append(space) |> ignore
-            sb.AppendLine(line) |> ignore
-        sb.ToString()
-
-    interface ICloudLogger with
-        override __.Log(entry : string) : unit = 
-            Console.Write("{0} {1}", DateTimeOffset.Now.ToString(format), prettyPrint entry)
-
-type CustomLogger (f : Action<string>) =
-    interface ICloudLogger with
-        override x.Log(entry : string) : unit = 
-            f.Invoke(entry)
  
  // TODO : Remove?       
 type ProcessLogger(config : ConfigurationId, pid : string) =
@@ -171,3 +147,33 @@ type ProcessLogger(config : ConfigurationId, pid : string) =
             | None -> query
             | Some f -> query.Where(f)
         Table.query config table query
+
+namespace MBrace.Azure
+
+open System
+open MBrace.Runtime
+
+type NullLogger () =
+    interface ICloudLogger with
+        member __.Log(_: string): unit = ()
+        
+type ConsoleLogger () =
+    let format = "ddMMyyyy HH:mm:ss.fff zzz" // 31012015 15:42:50.404 +02:00
+    let prettyPrint (message : string) =
+        let offset = format.Length + 4
+        let space = new String(' ', offset)
+        let sb = new System.Text.StringBuilder()
+        let mutable first = true
+        for line in message.Split('\n') do
+            if first then first <- false else sb.Append(space) |> ignore
+            sb.AppendLine(line) |> ignore
+        sb.ToString()
+
+    interface ICloudLogger with
+        override __.Log(entry : string) : unit = 
+            Console.Write("{0} {1}", DateTimeOffset.Now.ToString(format), prettyPrint entry)
+
+type CustomLogger (f : Action<string>) =
+    interface ICloudLogger with
+        override x.Log(entry : string) : unit = 
+            f.Invoke(entry)

--- a/src/MBrace.Azure.Runtime.Common/Records/Process.fs
+++ b/src/MBrace.Azure.Runtime.Common/Records/Process.fs
@@ -54,7 +54,7 @@ type ProcessRecord(pk, pid, pname, cancellationUri, state, createdt, completedt,
     new () = new ProcessRecord(null, null, null, null, null, Unchecked.defaultof<_>, Unchecked.defaultof<_>, false, null, null, null, null)
 
 type ProcessManager private (config : ConfigurationId) = 
-    let pk = "process"
+    let pk = "ProcessInfo"
     let table = config.RuntimeTable
     
     static member Create(configId : ConfigurationId) = new ProcessManager(configId)

--- a/src/MBrace.Azure.Runtime.Common/Records/Process.fs
+++ b/src/MBrace.Azure.Runtime.Common/Records/Process.fs
@@ -132,6 +132,7 @@ type ProcessManager private (config : ConfigurationId) =
             do! Table.delete<ProcessRecord> config table record
         if full then
             let! rks = Table.queryDynamic config table pid
+            rks |> Array.iter(fun de -> de.ETag <- "*")
             do! Table.deleteBatch config table rks
             let bc = ConfigurationRegistry.Resolve<ClientProvider>(config).BlobClient.GetContainerReference(config.RuntimeContainer)
             let dir = bc.GetDirectoryReference(pid)

--- a/src/MBrace.Azure.Runtime.Common/Records/Worker.fs
+++ b/src/MBrace.Azure.Runtime.Common/Records/Worker.fs
@@ -8,13 +8,14 @@ open System.Threading
 open MBrace
 open MBrace.Azure
 
-type WorkerRef (id : string, hostname : string, pid : int, pname : string, joined : DateTimeOffset, heartbeat : DateTimeOffset) =    
+type WorkerRef (id : string, hostname : string, pid : int, pname : string, joined : DateTimeOffset, heartbeat : DateTimeOffset, configurationHasH) =    
     member __.Id = id
     member __.Hostname = hostname 
     member __.ProcessId = pid 
     member __.ProcessName = pname 
     member __.InitializationTime = joined 
     member __.HeartbeatTime = heartbeat
+    member __.ConfigurationHash = configurationHasH
     override __.GetHashCode() = hash id
     override __.Equals(other:obj) =
         match other with
@@ -29,7 +30,7 @@ type WorkerRef (id : string, hostname : string, pid : int, pname : string, joine
         member __.Id = id
         member __.Type = "MBrace.Azure.Worker"
 
-type WorkerRecord(pk, id, hostname, pid, pname, joined) =
+type WorkerRecord(pk, id, hostname, pid, pname, joined, configurationHash) =
     inherit TableEntity(pk, id)
     member val Hostname : string = hostname with get, set
     member val Id = id : string with get, set
@@ -37,7 +38,7 @@ type WorkerRecord(pk, id, hostname, pid, pname, joined) =
     member val ProcessName :string = pname with get, set
     member val InitializationTime : DateTimeOffset = joined with get, set
     member val IsActive : bool = true with get, set
-
+    member val ConfigurationHash : int = configurationHash with get, set
     member val MaxJobs = 0 with get, set
     member val ActiveJobs = 0 with get, set
 
@@ -48,10 +49,10 @@ type WorkerRecord(pk, id, hostname, pid, pname, joined) =
     member val NetworkUp = Unchecked.defaultof<_> with get, set
     member val NetworkDown = Unchecked.defaultof<_> with get, set
 
-    new () = new WorkerRecord(null, null, null, -1, null, Unchecked.defaultof<_>)
+    new () = new WorkerRecord(null, null, null, -1, null, Unchecked.defaultof<_>, -1)
 
     member __.AsWorkerRef () = 
-        new WorkerRef(__.Id, __.Hostname, __.ProcessId, __.ProcessName, __.InitializationTime, __.Timestamp)
+        new WorkerRef(__.Id, __.Hostname, __.ProcessId, __.ProcessName, __.InitializationTime, __.Timestamp, __.ConfigurationHash)
 
     member __.UpdateCounters(counters : NodePerformanceInfo) =
             __.CPU <- counters.CpuUsage
@@ -109,7 +110,7 @@ type WorkerManager private (config : ConfigurationId) =
                 perfMon.Value.Start()
                 let ps = Diagnostics.Process.GetCurrentProcess()
                 let joined = DateTimeOffset.UtcNow
-                let w = new WorkerRecord(pk, workerId, Dns.GetHostName(), ps.Id, ps.ProcessName, joined)
+                let w = new WorkerRecord(pk, workerId, Dns.GetHostName(), ps.Id, ps.ProcessName, joined, hash config)
                 w.UpdateCounters(perfMon.Value.GetCounters())
                 do! Table.insertOrReplace<WorkerRecord> config table w //Worker might restart but keep id.
                 current := Some w

--- a/src/MBrace.Azure.Runtime.Common/Records/Worker.fs
+++ b/src/MBrace.Azure.Runtime.Common/Records/Worker.fs
@@ -6,6 +6,7 @@ open MBrace.Azure.Runtime
 open System.Net
 open System.Threading
 open MBrace
+open MBrace.Azure
 
 type WorkerRef (id : string, hostname : string, pid : int, pname : string, joined : DateTimeOffset, heartbeat : DateTimeOffset) =    
     member __.Id = id
@@ -59,15 +60,16 @@ type WorkerRecord(pk, id, hostname, pid, pname, joined) =
             __.NetworkUp <- counters.NetworkUsageUp
             __.NetworkDown <- counters.NetworkUsageDown
 
-type WorkerManager private (config, table : string) =
+type WorkerManager private (config : ConfigurationId) =
     let pk = "worker"
+    let table = config.RuntimeTable
 
     let current = ref None
     let perfMon = lazy new PerformanceMonitor()
     let mutable active = false
     let mutable activeJobs = 0
 
-    static member Create(config : Configuration) = new WorkerManager(config.ConfigurationId, config.DefaultTableOrContainer)
+    static member Create(config : ConfigurationId) = new WorkerManager(config)
 
     member __.ActiveJobs = activeJobs
     

--- a/src/MBrace.Azure.Runtime.Common/Records/Worker.fs
+++ b/src/MBrace.Azure.Runtime.Common/Records/Worker.fs
@@ -61,7 +61,7 @@ type WorkerRecord(pk, id, hostname, pid, pname, joined) =
             __.NetworkDown <- counters.NetworkUsageDown
 
 type WorkerManager private (config : ConfigurationId) =
-    let pk = "worker"
+    let pk = "WorkerRef"
     let table = config.RuntimeTable
 
     let current = ref None

--- a/src/MBrace.Azure.Runtime.Common/Resources.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources.fs
@@ -6,10 +6,10 @@ open MBrace.Azure
 
 
 type ResourceFactory private (configId : ConfigurationId) =
-    member __.RequestCounter(count) = Counter.Create(configId, count)
-    member __.RequestResultAggregator<'T>(count : int) = ResultAggregator<'T>.Create(configId, count)
-    member __.RequestCancellationTokenSource(?metadata, ?parent) = DistributedCancellationTokenSource.Create(configId, ?metadata = metadata, ?parent = parent)
-    member __.RequestResultCell<'T>(taskId) = ResultCell<'T>.Create(configId, taskId)
+    member __.RequestCounter(count, pid) = Counter.Create(configId, count, pid)
+    member __.RequestResultAggregator<'T>(count : int, pid) = ResultAggregator<'T>.Create(configId, count, pid)
+    member __.RequestCancellationTokenSource(pid, ?metadata, ?parent) = DistributedCancellationTokenSource.Create(configId, pid, ?metadata = metadata, ?parent = parent)
+    member __.RequestResultCell<'T>(taskId, pid) = ResultCell<'T>.Create(configId, taskId, pid)
     member __.RequestProcessLogger(pid) : MBrace.Runtime.ICloudLogger = 
         // TODO : change
         let pl = new ProcessLogger(configId, pid) 

--- a/src/MBrace.Azure.Runtime.Common/Resources.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources.fs
@@ -2,16 +2,17 @@
 
 open MBrace.Azure.Runtime
 open MBrace.Azure.Runtime.Common
+open MBrace.Azure
 
 
 type ResourceFactory private (configId : ConfigurationId) =
-    member __.RequestCounter(container, count) = Counter.Create(configId, container, count)
-    member __.RequestResultAggregator<'T>(container, count : int) = ResultAggregator<'T>.Create(configId, container, count)
-    member __.RequestCancellationTokenSource(container, ?metadata, ?parent) = DistributedCancellationTokenSource.Create(configId, container, ?metadata = metadata, ?parent = parent)
-    member __.RequestResultCell<'T>(taskId, container) = ResultCell<'T>.Create(configId, taskId, container)
-    member __.RequestProcessLogger(container, pid) : MBrace.Runtime.ICloudLogger = 
+    member __.RequestCounter(count) = Counter.Create(configId, count)
+    member __.RequestResultAggregator<'T>(count : int) = ResultAggregator<'T>.Create(configId, count)
+    member __.RequestCancellationTokenSource(?metadata, ?parent) = DistributedCancellationTokenSource.Create(configId, ?metadata = metadata, ?parent = parent)
+    member __.RequestResultCell<'T>(taskId) = ResultCell<'T>.Create(configId, taskId)
+    member __.RequestProcessLogger(pid) : MBrace.Runtime.ICloudLogger = 
         // TODO : change
-        let pl = new ProcessLogger(configId, container, pid) 
+        let pl = new ProcessLogger(configId, pid) 
         let lc = new LoggerCombiner()
         lc.Attach(new ConsoleLogger())
         lc.Attach(pl)

--- a/src/MBrace.Azure.Runtime.Common/Resources/AssemblyManager.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/AssemblyManager.fs
@@ -7,21 +7,21 @@ open Nessos.Vagabond
 open System
 open System.Runtime.Serialization
 open MBrace.Runtime.Vagabond
+open MBrace.Azure
 
-type AssemblyManager private (config : ConfigurationId, res : Uri) = 
+type AssemblyManager private (config : ConfigurationId) = 
     
     let filename id = sprintf "%s-%s" id.FullName (Convert.toBase32String id.ImageHash)
     
     let uploadPkg (pkg : AssemblyPackage) = 
         async { 
-            return! BlobCell.CreateIfNotExists(config, res.Primary, filename pkg.Id, fun () -> pkg) |> Async.Ignore
+            return! Blob.CreateIfNotExists(config, filename pkg.Id, fun () -> pkg) |> Async.Ignore
         }
     
     let downloadPkg (id : AssemblyId) : Async<AssemblyPackage> = 
         async { 
-            let uri = BlobCell<_>.GetUri(res.Primary, filename id)
-            let cell = BlobCell.OfUri(config, uri)
-            return! cell.GetValue()
+            let blob = Blob.FromPath(config, filename id)
+            return! blob.GetValue()
         }
     
     member __.UploadDependencies(ids : AssemblyId list) = 
@@ -54,17 +54,13 @@ type AssemblyManager private (config : ConfigurationId, res : Uri) =
 
     interface ISerializable with
         member x.GetObjectData(info : SerializationInfo, _ : StreamingContext) : unit = 
-            info.AddValue("uri", res, typeof<Uri>)
             info.AddValue("config", config, typeof<ConfigurationId>)
     
     new(info : SerializationInfo, _ : StreamingContext) = 
-        let res = info.GetValue("uri", typeof<Uri>) :?> Uri
         let config = info.GetValue("config", typeof<ConfigurationId>) :?> ConfigurationId
-        new AssemblyManager(config, res)
+        new AssemblyManager(config)
 
-    static member private GetUri(container) = uri "exporter:%s" container
-    static member Create(config, container : string) = 
-        let res = AssemblyManager.GetUri(container)
-        new AssemblyManager(config, res)
+    static member Create(config) = 
+        new AssemblyManager(config)
 
     

--- a/src/MBrace.Azure.Runtime.Common/Resources/AssemblyManager.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/AssemblyManager.fs
@@ -15,12 +15,12 @@ type AssemblyManager private (config : ConfigurationId) =
     
     let uploadPkg (pkg : AssemblyPackage) = 
         async { 
-            return! Blob.CreateIfNotExists(config, filename pkg.Id, fun () -> pkg) |> Async.Ignore
+            return! Blob.CreateIfNotExists(config, "assemblies", filename pkg.Id, fun () -> pkg) |> Async.Ignore
         }
     
     let downloadPkg (id : AssemblyId) : Async<AssemblyPackage> = 
         async { 
-            let blob = Blob.FromPath(config, filename id)
+            let blob = Blob.FromPath(config, "assemblies", filename id)
             return! blob.GetValue()
         }
     

--- a/src/MBrace.Azure.Runtime.Common/Resources/CancellationToken.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/CancellationToken.fs
@@ -9,20 +9,23 @@ open MBrace.Azure.Runtime.Common
 open Microsoft.WindowsAzure.Storage.Table
 open MBrace
 open System.Collections.Generic
+open MBrace.Azure
 
 [<Sealed>]
-type DistributedCancellationTokenSource internal (config, uri : Uri) = 
+type DistributedCancellationTokenSource internal (config : ConfigurationId, pk) = 
+    let table = config.RuntimeTable
+
     let cancel () = async {
         // Cancel current
-        let e = new CancellationTokenSourceEntity(uri.SecondaryWithScheme, IsCancellationRequested = true, ETag = "*")
-        do! Table.merge config uri.Primary e
+        let e = new CancellationTokenSourceEntity(pk, IsCancellationRequested = true, ETag = "*")
+        do! Table.merge config table e
             |> Async.Ignore
          
         // Gather all Uri's to update
         let visited = new HashSet<string>()
-        let uris = new ResizeArray<string * string>()
+        let uris = new ResizeArray<string>()
 
-        let rec walk table pk = async {
+        let rec walk pk = async {
             // Get all CTS links for current CTS.
             if visited.Add(pk) then
                 let! children = Table.queryPK<CancellationTokenLinkEntity> config table pk
@@ -31,13 +34,13 @@ type DistributedCancellationTokenSource internal (config, uri : Uri) =
                          |> Seq.toArray
                 for e in ch do
                     if not <| visited.Contains(e.RowKey) then
-                        uris.Add(e.ChildTable, e.RowKey)
-                        do! walk e.ChildTable e.RowKey
+                        uris.Add(e.RowKey)
+                        do! walk e.RowKey
         }
-        do! walk uri.Primary uri.SecondaryWithScheme
+        do! walk pk
         
         do! uris
-            |> Seq.map (fun (table, pk) -> async {
+            |> Seq.map (fun pk -> async {
                 let e = new CancellationTokenSourceEntity(pk, IsCancellationRequested = true, ETag = "*")
                 do! Table.merge config table e
                     |> Async.Ignore })
@@ -48,7 +51,7 @@ type DistributedCancellationTokenSource internal (config, uri : Uri) =
     let mutable isCancellationRequested = false
     let check() = 
         async { 
-            let! e = Table.read<CancellationTokenSourceEntity> config uri.Primary uri.SecondaryWithScheme String.Empty
+            let! e = Table.read<CancellationTokenSourceEntity> config table pk String.Empty
             isCancellationRequested <- e.IsCancellationRequested
             return isCancellationRequested
         }
@@ -80,35 +83,35 @@ type DistributedCancellationTokenSource internal (config, uri : Uri) =
     
     member __.CancelAsync() = cancel ()
     member __.Cancel() = Async.RunSync(__.CancelAsync())
-    member __.Uri = uri
     
-    override this.ToString() = uri.ToString()
+    override this.ToString() = pk
+
+    member this.Path = pk
 
     interface ISerializable with
         member x.GetObjectData(info: SerializationInfo, _ : StreamingContext): unit = 
-            info.AddValue("uri", uri, typeof<Uri>)
+            info.AddValue("pk", pk, typeof<string>)
             info.AddValue("config", config, typeof<ConfigurationId>)
 
     new(info: SerializationInfo, _ : StreamingContext) =
-        let uri = info.GetValue("uri", typeof<Uri>) :?> Uri
+        let pk = info.GetValue("pk", typeof<string>) :?> string
         let config = info.GetValue("config", typeof<ConfigurationId>) :?> ConfigurationId
-        new DistributedCancellationTokenSource(config, uri)
+        new DistributedCancellationTokenSource(config, pk)
 
-    static member private GetUri(container, id) = uri "dcts:%s/%s" container id
-    static member FromUri(config : ConfigurationId, uri) = new DistributedCancellationTokenSource(config, uri)
-    static member Create(config, container : string, ?metadata, ?parent : DistributedCancellationTokenSource) = 
+    static member FromPath(config : ConfigurationId, pk) = new DistributedCancellationTokenSource(config, pk)
+    static member Create(config, ?metadata, ?parent : DistributedCancellationTokenSource) = 
         async {
             // Create DCTS record 
-            let childUri = DistributedCancellationTokenSource.GetUri(container, guid())
-            let ctse = new CancellationTokenSourceEntity(childUri.SecondaryWithScheme) 
+            let childUri = guid()
+            let ctse = new CancellationTokenSourceEntity(childUri) 
             metadata |> Option.iter(fun m -> ctse.Metadata <- m)      
-            do! Table.insert<CancellationTokenSourceEntity> config childUri.Primary ctse
+            do! Table.insert<CancellationTokenSourceEntity> config config.RuntimeTable ctse
             // Create DCTS Link between child and parent, store in parents table.
             match parent with
             | None -> ()
             | Some p -> 
-                let link = new CancellationTokenLinkEntity(p.Uri.SecondaryWithScheme, childUri.SecondaryWithScheme, childUri.Primary)
-                do! Table.insert<CancellationTokenLinkEntity> config p.Uri.Primary link
+                let link = new CancellationTokenLinkEntity(p.Path, childUri)
+                do! Table.insert<CancellationTokenLinkEntity> config config.RuntimeTable link
             let dcts = new DistributedCancellationTokenSource(config, childUri)
             // This step is essential. If parent is already canceled
             // then there is none to run Cancel and update future child tokens.

--- a/src/MBrace.Azure.Runtime.Common/Resources/CancellationToken.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/CancellationToken.fs
@@ -12,38 +12,38 @@ open System.Collections.Generic
 open MBrace.Azure
 
 [<Sealed>]
-type DistributedCancellationTokenSource internal (config : ConfigurationId, pk) = 
+type DistributedCancellationTokenSource internal (config : ConfigurationId, pk, rk) = 
     let table = config.RuntimeTable
 
     let cancel () = async {
         // Cancel current
-        let e = new CancellationTokenSourceEntity(pk, IsCancellationRequested = true, ETag = "*")
+        let e = new CancellationTokenSourceEntity(pk, rk, Unchecked.defaultof<_>, IsCancellationRequested = true, ETag = "*")
         do! Table.merge config table e
             |> Async.Ignore
          
         // Gather all Uri's to update
         let visited = new HashSet<string>()
-        let uris = new ResizeArray<string>()
+        let uris = new ResizeArray<string * string>()
 
-        let rec walk pk = async {
+        let rec walk pk rk = async {
             // Get all CTS links for current CTS.
-            if visited.Add(pk) then
-                let! children = Table.queryPK<CancellationTokenLinkEntity> config table pk
-                let ch = children 
-                         |> Seq.filter (fun e -> e.RowKey <> String.Empty) // CTSEntity has empty RK
-                         |> Seq.toArray
-                for e in ch do
-                    if not <| visited.Contains(e.RowKey) then
-                        uris.Add(e.RowKey)
-                        do! walk e.RowKey
+            if visited.Add(rk) then
+                let! e = Table.read<CancellationTokenSourceEntity> config table pk rk
+                let ch = e.GetLinks()
+                for (pk, rk) as e in ch do
+                    if not <| visited.Contains(rk) then
+                        uris.Add(e)
+                        do! walk pk rk
         }
-        do! walk pk
+        do! walk pk rk
         
         do! uris
-            |> Seq.map (fun pk -> async {
-                let e = new CancellationTokenSourceEntity(pk, IsCancellationRequested = true, ETag = "*")
-                do! Table.merge config table e
-                    |> Async.Ignore })
+            |> Seq.groupBy (fun (pk, _) -> pk)
+            |> Seq.map (fun (_, xs) -> 
+                xs 
+                |> Seq.map (fun (pk, rk) -> new CancellationTokenSourceEntity(pk, rk, Unchecked.defaultof<_>, IsCancellationRequested = true, ETag = "*"))
+                |> Table.mergeBatch config table
+                )
             |> Async.Parallel
             |> Async.Ignore
     }
@@ -51,7 +51,7 @@ type DistributedCancellationTokenSource internal (config : ConfigurationId, pk) 
     let mutable isCancellationRequested = false
     let check() = 
         async { 
-            let! e = Table.read<CancellationTokenSourceEntity> config table pk String.Empty
+            let! e = Table.read<CancellationTokenSourceEntity> config table pk rk
             isCancellationRequested <- e.IsCancellationRequested
             return isCancellationRequested
         }
@@ -84,35 +84,45 @@ type DistributedCancellationTokenSource internal (config : ConfigurationId, pk) 
     member __.CancelAsync() = cancel ()
     member __.Cancel() = Async.RunSync(__.CancelAsync())
     
-    override this.ToString() = pk
+    override this.ToString() = sprintf "%s/%s" pk rk
 
-    member this.Path = pk
-
+    member this.PartitionKey = pk
+    member this.RowKey = rk
+    member this.Links = 
+        Async.RunSync <| async {
+            let! e = Table.read<CancellationTokenSourceEntity> config config.RuntimeTable pk rk
+            return e.GetLinks()
+        }
+    
     interface ISerializable with
         member x.GetObjectData(info: SerializationInfo, _ : StreamingContext): unit = 
             info.AddValue("pk", pk, typeof<string>)
+            info.AddValue("rk", rk, typeof<string>)
             info.AddValue("config", config, typeof<ConfigurationId>)
 
     new(info: SerializationInfo, _ : StreamingContext) =
         let pk = info.GetValue("pk", typeof<string>) :?> string
+        let rk = info.GetValue("rk", typeof<string>) :?> string
         let config = info.GetValue("config", typeof<ConfigurationId>) :?> ConfigurationId
-        new DistributedCancellationTokenSource(config, pk)
+        new DistributedCancellationTokenSource(config, pk, rk)
 
-    static member FromPath(config : ConfigurationId, pk) = new DistributedCancellationTokenSource(config, pk)
-    static member Create(config, ?metadata, ?parent : DistributedCancellationTokenSource) = 
+    static member FromPath(config : ConfigurationId, pid, rk) = new DistributedCancellationTokenSource(config, pid, rk)
+    static member Create(config, pid, ?metadata, ?parent : DistributedCancellationTokenSource) = 
         async {
             // Create DCTS record 
             let childUri = guid()
-            let ctse = new CancellationTokenSourceEntity(childUri) 
+            let ctse = new CancellationTokenSourceEntity(pid, childUri, List.empty) 
             metadata |> Option.iter(fun m -> ctse.Metadata <- m)      
             do! Table.insert<CancellationTokenSourceEntity> config config.RuntimeTable ctse
-            // Create DCTS Link between child and parent, store in parents table.
+            // Create DCTS Link between child and parent, store in parent.
             match parent with
             | None -> ()
             | Some p -> 
-                let link = new CancellationTokenLinkEntity(p.Path, childUri)
-                do! Table.insert<CancellationTokenLinkEntity> config config.RuntimeTable link
-            let dcts = new DistributedCancellationTokenSource(config, childUri)
+                let! _ = Table.transact2<CancellationTokenSourceEntity> 
+                            config config.RuntimeTable p.PartitionKey p.RowKey 
+                            (fun p -> new CancellationTokenSourceEntity(p.PartitionKey, p.RowKey, (pid, childUri) :: p.GetLinks(), ETag = p.ETag))
+                ()
+            let dcts = new DistributedCancellationTokenSource(config, pid, childUri)
             // This step is essential. If parent is already canceled
             // then there is none to run Cancel and update future child tokens.
             match parent with

--- a/src/MBrace.Azure.Runtime.Common/Resources/Cells.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/Cells.fs
@@ -5,36 +5,35 @@ open System.Runtime.Serialization
 open MBrace.Azure.Runtime
 open MBrace.Azure.Runtime.Common
 open System.IO
+open MBrace.Azure
 
 
-type BlobCell<'T> internal (config : ConfigurationId, res : Uri) = 
+type Blob<'T> internal (config : ConfigurationId, filename) = 
     member __.GetValue() : Async<'T> = 
         async { 
-            let container = ConfigurationRegistry.Resolve<ClientProvider>(config).BlobClient.GetContainerReference(res.Primary)
-            use! s = container.GetBlockBlobReference(res.SecondaryWithScheme).OpenReadAsync()
+            let container = ConfigurationRegistry.Resolve<ClientProvider>(config).BlobClient.GetContainerReference(config.RuntimeContainer)
+            use! s = container.GetBlockBlobReference(filename).OpenReadAsync()
             return Configuration.Pickler.Deserialize<'T>(s) 
         }
     
-    member __.Uri = res
+    member __.Filename = filename
     
     interface ISerializable with
         member x.GetObjectData(info: SerializationInfo, _: StreamingContext): unit = 
-            info.AddValue("uri", res, typeof<Uri>)
+            info.AddValue("filename", filename, typeof<string>)
             info.AddValue("config", config, typeof<ConfigurationId>)
 
     new(info: SerializationInfo, _: StreamingContext) =
-        let res = info.GetValue("uri", typeof<Uri>) :?> Uri
+        let filename = info.GetValue("filename", typeof<string>) :?> string
         let config = info.GetValue("config", typeof<ConfigurationId>) :?> ConfigurationId
-        new BlobCell<'T>(config, res)
+        new Blob<'T>(config, filename)
 
-    static member OfUri<'T>(config, res : Uri) = new BlobCell<'T>(config, res)
-    static member GetUri(container, id) = uri "blobcell:%s/%s" container id
-    static member CreateIfNotExists(config, container : string, id : string, f : unit -> 'T) = 
+    static member FromPath(config : ConfigurationId, filename) = new Blob<'T>(config, filename)
+    static member CreateIfNotExists(config, filename : string, f : unit -> 'T) = 
         async { 
-            let res = BlobCell<_>.GetUri(container, id)
-            let c = ConfigurationRegistry.Resolve<ClientProvider>(config).BlobClient.GetContainerReference(res.Primary)
+            let c = ConfigurationRegistry.Resolve<ClientProvider>(config).BlobClient.GetContainerReference(config.RuntimeContainer)
             let! _ = c.CreateIfNotExistsAsync()
-            let b = c.GetBlockBlobReference(res.SecondaryWithScheme)
+            let b = c.GetBlockBlobReference(filename)
             let! exists = b.ExistsAsync()
             if not exists then
                 let tmpPath = Path.GetTempFileName()
@@ -44,9 +43,9 @@ type BlobCell<'T> internal (config : ConfigurationId, res : Uri) =
                 do! b.UploadFromStreamAsync(tmp) 
                 tmp.Dispose()
                 File.Delete(tmpPath)
-                return new BlobCell<'T>(config, res)
+                return new Blob<'T>(config, filename)
             else
-                return BlobCell.OfUri<'T>(config, res)
+                return Blob.FromPath(config, filename)
         }
-    static member Create(config, container : string, f : unit -> 'T) = 
-        BlobCell.CreateIfNotExists(config, container, guid(), f)
+    static member Create(config, f : unit -> 'T) = 
+        Blob<'T>.CreateIfNotExists(config, guid(), f)

--- a/src/MBrace.Azure.Runtime.Common/Resources/Cells.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/Cells.fs
@@ -8,32 +8,38 @@ open System.IO
 open MBrace.Azure
 
 
-type Blob<'T> internal (config : ConfigurationId, filename) = 
+type Blob<'T> internal (config : ConfigurationId, prefix, filename) = 
     member __.GetValue() : Async<'T> = 
         async { 
             let container = ConfigurationRegistry.Resolve<ClientProvider>(config).BlobClient.GetContainerReference(config.RuntimeContainer)
-            use! s = container.GetBlockBlobReference(filename).OpenReadAsync()
+            use! s = container.GetBlockBlobReference(sprintf "%s/%s" prefix filename).OpenReadAsync()
             return Configuration.Pickler.Deserialize<'T>(s) 
         }
     
-    member __.Filename = filename
+    member __.Path = sprintf "%s/%s" prefix filename
     
     interface ISerializable with
         member x.GetObjectData(info: SerializationInfo, _: StreamingContext): unit = 
+            info.AddValue("prefix", prefix, typeof<string>)
             info.AddValue("filename", filename, typeof<string>)
             info.AddValue("config", config, typeof<ConfigurationId>)
 
     new(info: SerializationInfo, _: StreamingContext) =
         let filename = info.GetValue("filename", typeof<string>) :?> string
+        let prefix = info.GetValue("prefix", typeof<string>) :?> string
         let config = info.GetValue("config", typeof<ConfigurationId>) :?> ConfigurationId
-        new Blob<'T>(config, filename)
+        new Blob<'T>(config, prefix, filename)
 
-    static member FromPath(config : ConfigurationId, filename) = new Blob<'T>(config, filename)
-    static member CreateIfNotExists(config, filename : string, f : unit -> 'T) = 
+    static member FromPath(config : ConfigurationId, path : string) = 
+        let p = path.Split('/')
+        Blob<'T>.FromPath(config, p.[0], p.[1])
+    static member FromPath(config : ConfigurationId, prefix, file) = 
+        new Blob<'T>(config, prefix, file)
+    static member CreateIfNotExists(config, prefix, filename : string, f : unit -> 'T) = 
         async { 
             let c = ConfigurationRegistry.Resolve<ClientProvider>(config).BlobClient.GetContainerReference(config.RuntimeContainer)
             let! _ = c.CreateIfNotExistsAsync()
-            let b = c.GetBlockBlobReference(filename)
+            let b = c.GetBlockBlobReference(sprintf "%s/%s" prefix filename)
             let! exists = b.ExistsAsync()
             if not exists then
                 let tmpPath = Path.GetTempFileName()
@@ -43,9 +49,7 @@ type Blob<'T> internal (config : ConfigurationId, filename) =
                 do! b.UploadFromStreamAsync(tmp) 
                 tmp.Dispose()
                 File.Delete(tmpPath)
-                return new Blob<'T>(config, filename)
+                return new Blob<'T>(config, prefix, filename)
             else
-                return Blob.FromPath(config, filename)
+                return Blob.FromPath(config, prefix, filename)
         }
-    static member Create(config, f : unit -> 'T) = 
-        Blob<'T>.CreateIfNotExists(config, guid(), f)

--- a/src/MBrace.Azure.Runtime.Common/Resources/Counters.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/Counters.fs
@@ -32,11 +32,11 @@ type IntCell internal (config : ConfigurationId, pk, rk) =
         let rk = info.GetValue("rk", typeof<string>) :?> string
         new IntCell(config, pk, rk)
 
-    static member Create(config, pk : string, value : int) = 
+    static member Create(config, name : string, value : int, pid) = 
         async { 
-            let e = new CounterEntity(pk, value)
+            let e = new CounterEntity(pid, name, value)
             do! Table.insert config config.RuntimeTable e
-            return new IntCell(config, pk, String.Empty)
+            return new IntCell(config, pid, name)
         }
 
 
@@ -57,14 +57,14 @@ type Latch internal (config, pk, rk) =
         let rk = info.GetValue("rk", typeof<string>) :?> string
         new Latch(config, pk, rk)
 
-    static member Create(config, pk : string, value : int) = 
+    static member Create(config, name : string, value : int, pid) = 
         async { 
-            let e = new LatchEntity(pk, value, value)
+            let e = new LatchEntity(pid, name, value, value)
             do! Table.insert config config.RuntimeTable e
-            return new Latch(config, pk, e.RowKey)
+            return new Latch(config, pid, name)
         }
-    static member Create(config, value : int) = 
-        Latch.Create(config, guid(), value)
+    static member Create(config, value : int, pid) = 
+        Latch.Create(config, guid(), value, pid)
 
 type Counter internal (config, pk, rk) = 
     inherit IntCell(config, pk, rk)
@@ -83,11 +83,11 @@ type Counter internal (config, pk, rk) =
         let rk = info.GetValue("rk", typeof<string>) :?> string
         new Counter(config, pk, rk)
 
-    static member Create(config, pk : string, value : int) = 
+    static member Create(config, name : string, value : int, pid) = 
         async { 
-            let e = new CounterEntity(pk, value)
+            let e = new CounterEntity(pid, name, value)
             do! Table.insert config config.RuntimeTable e
-            return new Counter(config, pk, e.RowKey)
+            return new Counter(config, pid, name)
         }
-    static member Create(config, value : int) = 
-        Counter.Create(config, guid(), value)
+    static member Create(config, value : int, pid) = 
+        Counter.Create(config, guid(), value, pid)

--- a/src/MBrace.Azure.Runtime.Common/Resources/Counters.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/Counters.fs
@@ -6,90 +6,88 @@ open System.Runtime.Serialization
 open MBrace.Continuation
 open MBrace.Azure.Runtime
 open MBrace.Azure.Runtime.Common
+open MBrace.Azure
 
-type IntCell internal (config : ConfigurationId, res : Uri) = 
+type IntCell internal (config : ConfigurationId, pk, rk) = 
+    let table = config.RuntimeTable
     member __.Value = 
-        let e = Table.read<CounterEntity> config res.Primary res.SecondaryWithScheme String.Empty |> Async.RunSync
+        let e = Table.read<CounterEntity> config table pk rk |> Async.RunSync
         e.Value
     
     member internal __.Update(updatef : int -> int) = 
         async { 
-            let! e = Table.transact<CounterEntity> config res.Primary res.SecondaryWithScheme String.Empty (fun e -> e.Value <- updatef e.Value)
+            let! e = Table.transact<CounterEntity> config table pk rk (fun e -> e.Value <- updatef e.Value)
             return e.Value
         }
     
-    member __.Uri = res
-
     interface ISerializable with
         member x.GetObjectData(info: SerializationInfo, _: StreamingContext): unit = 
-            info.AddValue("uri", res, typeof<Uri>)
             info.AddValue("config", config, typeof<ConfigurationId>)
+            info.AddValue("pk", pk, typeof<string>)
+            info.AddValue("rk", rk, typeof<string>)
 
     new(info: SerializationInfo, _: StreamingContext) =
-        let res = info.GetValue("uri", typeof<Uri>) :?> Uri
         let config = info.GetValue("config", typeof<ConfigurationId>) :?> ConfigurationId
-        new IntCell(config, res)
+        let pk = info.GetValue("pk", typeof<string>) :?> string
+        let rk = info.GetValue("rk", typeof<string>) :?> string
+        new IntCell(config, pk, rk)
 
-    static member GetUri(container, id) = uri "intcell:%s/%s" container id
-    static member Create(config, container : string, value : int) = 
+    static member Create(config, pk : string, value : int) = 
         async { 
-            let res = IntCell.GetUri(container, guid () )
-            let e = new CounterEntity(res.SecondaryWithScheme, value)
-            do! Table.insert config res.Primary e
-            return new IntCell(config, res)
+            let e = new CounterEntity(pk, value)
+            do! Table.insert config config.RuntimeTable e
+            return new IntCell(config, pk, String.Empty)
         }
 
 
-type Latch internal (config, res : Uri) = 
-    inherit IntCell(config, res)
+type Latch internal (config, pk, rk) = 
+    inherit IntCell(config, pk, rk)
 
     member __.Decrement() = base.Update(fun v -> v - 1)
 
-    member __.Uri = res
-    
     interface ISerializable with
         member x.GetObjectData(info: SerializationInfo, _: StreamingContext): unit = 
-            info.AddValue("uri", res, typeof<Uri>)
             info.AddValue("config", config, typeof<ConfigurationId>)
+            info.AddValue("pk", pk, typeof<string>)
+            info.AddValue("rk", rk, typeof<string>)
 
     new(info: SerializationInfo, _: StreamingContext) =
-        let res = info.GetValue("uri", typeof<Uri>) :?> Uri
         let config = info.GetValue("config", typeof<ConfigurationId>) :?> ConfigurationId
-        new Latch(config, res)
+        let pk = info.GetValue("pk", typeof<string>) :?> string
+        let rk = info.GetValue("rk", typeof<string>) :?> string
+        new Latch(config, pk, rk)
 
-    static member private GetUri(container, id) = uri "latch:%s/%s" container id
-    static member Create(config, container : string, id : string, value : int) = 
+    static member Create(config, pk : string, value : int) = 
         async { 
-            let res = Latch.GetUri(container, id)
-            let e = new LatchEntity(res.SecondaryWithScheme, value, value)
-            do! Table.insert config res.Primary e
-            return new Latch(config, res)
+            let e = new LatchEntity(pk, value, value)
+            do! Table.insert config config.RuntimeTable e
+            return new Latch(config, pk, e.RowKey)
         }
-    static member Create(config, container : string, value : int) = 
-        Latch.Create(config, container, guid(), value)
+    static member Create(config, value : int) = 
+        Latch.Create(config, guid(), value)
 
-type Counter internal (config, res : Uri) = 
-    inherit IntCell(config, res)
-    
-    member __.Increment() = base.Update(fun x -> x + 1)
-    
-    member __.Uri = res
+type Counter internal (config, pk, rk) = 
+    inherit IntCell(config, pk, rk)
+
+    member __.Increment() = base.Update(fun v -> v + 1)
 
     interface ISerializable with
         member x.GetObjectData(info: SerializationInfo, _: StreamingContext): unit = 
-            info.AddValue("uri", res, typeof<Uri>)
             info.AddValue("config", config, typeof<ConfigurationId>)
+            info.AddValue("pk", pk, typeof<string>)
+            info.AddValue("rk", rk, typeof<string>)
 
     new(info: SerializationInfo, _: StreamingContext) =
-        let res = info.GetValue("uri", typeof<Uri>) :?> Uri
         let config = info.GetValue("config", typeof<ConfigurationId>) :?> ConfigurationId
-        new Counter(config, res)
+        let pk = info.GetValue("pk", typeof<string>) :?> string
+        let rk = info.GetValue("rk", typeof<string>) :?> string
+        new Counter(config, pk, rk)
 
-    static member private GetUri(container, id) = uri "counter:%s/%s" container id
-    static member Create(config, container : string, value : int) = 
+    static member Create(config, pk : string, value : int) = 
         async { 
-            let res = Counter.GetUri(container, guid())
-            let e = new CounterEntity(res.SecondaryWithScheme, value)
-            do! Table.insert config res.Primary e
-            return new Counter(config, res)
+            let e = new CounterEntity(pk, value)
+            do! Table.insert config config.RuntimeTable e
+            return new Counter(config, pk, e.RowKey)
         }
+    static member Create(config, value : int) = 
+        Counter.Create(config, guid(), value)

--- a/src/MBrace.Azure.Runtime.Common/Resources/Result.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/Result.fs
@@ -10,6 +10,7 @@ open MBrace.Continuation
 open MBrace
 open System.Threading
 open MBrace.Azure
+open Microsoft.WindowsAzure.Storage.Table
 
 /// Result value
 type Result<'T> =
@@ -75,14 +76,14 @@ type ResultCell<'T> internal (config : ConfigurationId, pk) as self =
         async {
             let! bc = Blob.Create(config, fun () -> result)
             let uri = bc.Filename
-            let e = new LightCellEntity(pk, uri.ToString(), ETag = "*")
+            let e = new BlobReferenceEntity(pk, uri.ToString(), ETag = "*")
             let! _ = Table.merge config table e
             return ()
         }
 
     member __.TryGetResult() : Async<Result<'T> option> = 
         async {
-            let! e = Table.read<LightCellEntity> config table pk String.Empty
+            let! e = Table.read<BlobReferenceEntity> config table pk String.Empty
             if String.IsNullOrEmpty e.Uri then return None
             else
                 let bc = Blob.FromPath(config, e.Uri)
@@ -109,30 +110,48 @@ type ResultCell<'T> internal (config : ConfigurationId, pk) as self =
         new ResultCell<'T>(config, pk)
 
     static member FromPath(config : ConfigurationId, uri) = new ResultCell<'T>(config, uri)
-    static member Create(config, id) : Async<ResultCell<'T>> = 
+    static member Create(config, id, pid) : Async<ResultCell<'T>> = 
         async { 
-            let e = new LightCellEntity(id, null)
-            do! Table.insert<LightCellEntity> config config.RuntimeTable e
+            let e = new BlobReferenceEntity(pid, id, null, EntityType = "RESULT")
+            do! Table.insert<BlobReferenceEntity> config config.RuntimeTable e
             return new ResultCell<'T>(config, id)
         }
 
 
-type ResultAggregator<'T> internal (config : ConfigurationId, pk) = 
+type ResultAggregator<'T> internal (config : ConfigurationId, pk, rk, size) = 
+    static let mkRowKey name i = sprintf "%s:%010d" name i
+    
     let table = config.RuntimeTable
+
+    let getEntities () = async {
+        let pkFilter = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, pk)
+        let lower = mkRowKey rk 0
+        let upper = mkRowKey rk size
+        let rkFilter = 
+            TableQuery.CombineFilters(
+                TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.LessThanOrEqual, upper),
+                TableOperators.And,
+                TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.GreaterThanOrEqual, lower))
+
+        let query = TableQuery<BlobReferenceEntity>().Where(TableQuery.CombineFilters(pkFilter, TableOperators.And, rkFilter))
+
+        let! xs = Table.query<BlobReferenceEntity> config table query
+        return xs
+    }
 
     let completed () =
         async {
-            let! xs = Table.queryPK<ResultAggregatorEntity> config table pk
-            return xs |> Seq.forall (fun e -> e.Uri <> String.Empty)
+            let! xs = getEntities()
+            return xs |> Seq.forall (fun e -> not <| String.IsNullOrEmpty(e.Uri))
         }
 
     member __.SetResult(index : int, value : 'T) : Async<bool> = 
         async { 
-            let e = new ResultAggregatorEntity(pk, index, null, ETag = "*")
+            let e = new BlobReferenceEntity(pk, mkRowKey rk index, null, ETag = "*")
             let! bc = Blob.Create(config, fun () -> value)
             e.Uri <- bc.Filename
-            let! _ = Table.replace config table e
-            return __.Complete
+            let! _ = Table.merge config table e
+            return! completed()
         }
     
     member __.Complete = Async.RunSync(completed())
@@ -142,14 +161,14 @@ type ResultAggregator<'T> internal (config : ConfigurationId, pk) =
             if not __.Complete then 
                 return! Async.Raise <| new InvalidOperationException("Result aggregator incomplete.")
             else
-                let! xs = Table.queryPK<ResultAggregatorEntity> config table pk
+                let! xs = getEntities()
                 let bs = 
                     xs
-                    |> Seq.sortBy (fun x -> x.Index)
+                    |> Seq.sortBy (fun x -> x.RowKey)
                     |> Seq.map (fun x -> x.Uri)
                     |> Seq.map (fun x -> Blob<_>.FromPath(config, x))
                     |> Seq.toArray
-            
+
                 let re = Array.zeroCreate<'T> bs.Length
                 let i = ref 0
                 for b in bs do
@@ -162,20 +181,25 @@ type ResultAggregator<'T> internal (config : ConfigurationId, pk) =
     interface ISerializable with
         member x.GetObjectData(info: SerializationInfo, _: StreamingContext): unit = 
             info.AddValue("pk", pk, typeof<string>)
+            info.AddValue("rk", rk, typeof<string>)
+            info.AddValue("size", size, typeof<string>)
             info.AddValue("config", config, typeof<ConfigurationId>)
 
     new(info: SerializationInfo, _: StreamingContext) =
         let pk = info.GetValue("pk", typeof<string>) :?> string
+        let rk = info.GetValue("rk", typeof<string>) :?> string
+        let size = info.GetValue("size", typeof<int>) :?> int
         let config = info.GetValue("config", typeof<ConfigurationId>) :?> ConfigurationId
-        new ResultAggregator<'T>(config, pk)
+        new ResultAggregator<'T>(config, pk, rk, size)
 
-    static member Create<'T>(config, size : int) = 
+    static member Create<'T>(config, size, pid) = 
         async { 
-            let pk = guid()
+            let name = guid()
             let entities = seq {
                 for i = 0 to size - 1 do
-                    yield new ResultAggregatorEntity(pk, i, String.Empty)
+                    let name = mkRowKey name i
+                    yield new BlobReferenceEntity(pid, name, String.Empty, EntityType = "AGGR")
             }
-                do! Table.insertBatch config config.RuntimeTable entities
-            return new ResultAggregator<'T>(config, pk)
+            do! Table.insertBatch config config.RuntimeTable entities
+            return new ResultAggregator<'T>(config, pid, name, size)
         }

--- a/src/MBrace.Azure.Runtime.Common/Resources/Result.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/Result.fs
@@ -188,7 +188,7 @@ type ResultAggregator<'T> internal (config : ConfigurationId, pk, rk, size) =
         member x.GetObjectData(info: SerializationInfo, _: StreamingContext): unit = 
             info.AddValue("pk", pk, typeof<string>)
             info.AddValue("rk", rk, typeof<string>)
-            info.AddValue("size", size, typeof<string>)
+            info.AddValue("size", size, typeof<int>)
             info.AddValue("config", config, typeof<ConfigurationId>)
 
     new(info: SerializationInfo, _: StreamingContext) =

--- a/src/MBrace.Azure.Runtime.Common/Resources/Result.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/Result.fs
@@ -114,8 +114,7 @@ type ResultCell<'T> internal (config : ConfigurationId, pk, rk) as self =
     static member FromPath(config : ConfigurationId, path : string) = 
         let pkrk = path.Split('/')
         new ResultCell<'T>(config, pkrk.[0], pkrk.[1])
-    static member Create(config, pid) : Async<ResultCell<'T>> = 
-        ResultCell.Create(config, guid(), pid)
+
     static member Create(config, id, pid) : Async<ResultCell<'T>> = 
         async { 
             let e = new BlobReferenceEntity(pid, id, null, EntityType = "RESULT")

--- a/src/MBrace.Azure.Runtime.Common/Resources/Result.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/Result.fs
@@ -74,8 +74,8 @@ type ResultCell<'T> internal (config : ConfigurationId, pk, rk) as self =
 
     member __.SetResult(result : Result<'T>) : Async<unit> =
         async {
-            let! bc = Blob.Create(config, fun () -> result)
-            let uri = bc.Filename
+            let! bc = Blob.CreateIfNotExists(config, pk, guid(), fun () -> result)
+            let uri = bc.Path
             let e = new BlobReferenceEntity(pk, rk, uri.ToString(), ETag = "*")
             let! _ = Table.merge config table e
             return ()
@@ -154,8 +154,8 @@ type ResultAggregator<'T> internal (config : ConfigurationId, pk, rk, size) =
     member __.SetResult(index : int, value : 'T) : Async<bool> = 
         async { 
             let e = new BlobReferenceEntity(pk, mkRowKey rk index, null, ETag = "*")
-            let! bc = Blob.Create(config, fun () -> value)
-            e.Uri <- bc.Filename
+            let! bc = Blob.CreateIfNotExists(config, pk, guid(), fun () -> value)
+            e.Uri <- bc.Path
             let! _ = Table.merge config table e
             return! completed()
         }

--- a/src/MBrace.Azure.Runtime.Common/Resources/TableStorage.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/TableStorage.fs
@@ -138,14 +138,14 @@ module Table =
     let insertOrReplace<'T when 'T :> ITableEntity> config table (e : 'T) : Async<unit> = 
         TableOperation.InsertOrReplace(e) |> exec config table |> Async.Ignore
     
-    let queryDynamic config table pk : Async<DynamicTableEntity seq> =
+    let queryDynamic config table pk : Async<DynamicTableEntity []> =
         async {  
             let t = ConfigurationRegistry.Resolve<ClientProvider>(config).TableClient.GetTableReference(table)
             let q = TableQuery<DynamicTableEntity>()
                         .Where(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, pk))
                         .Select([|"RowKey"|])
             return t.ExecuteQuery(q)
-
+                   |> Seq.toArray
         }
 
     let read<'T when 'T :> ITableEntity> config table pk rk : Async<'T> = 
@@ -159,13 +159,15 @@ module Table =
         async {
             let t = ConfigurationRegistry.Resolve<ClientProvider>(config).TableClient.GetTableReference(table)
             return t.ExecuteQuery<'T>(query)
+                   |> Seq.toArray
         }
 
-    let queryPK<'T when 'T : (new : unit -> 'T) and 'T :> ITableEntity> config table pk : Async<'T seq> = 
+    let queryPK<'T when 'T : (new : unit -> 'T) and 'T :> ITableEntity> config table pk : Async<'T []> = 
         async {  
             let t = ConfigurationRegistry.Resolve<ClientProvider>(config).TableClient.GetTableReference(table)
             let q = TableQuery<'T>().Where(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, pk))
             return t.ExecuteQuery<'T>(q)
+                   |> Seq.toArray
         }
     
     let merge<'T when 'T :> ITableEntity> config table (e : 'T) : Async<'T> = 

--- a/src/MBrace.Azure.Runtime.Common/Resources/TableStorage.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/TableStorage.fs
@@ -11,8 +11,13 @@ open MBrace.Azure.Runtime
 //
 // Parameterless public ctor is needed.
 
+[<AbstractClass>]
+type RuntimeEntity (pk, rk, entity) =
+    inherit TableEntity(pk, rk)
+    member val EntityType = entity with get, set
+
 type CounterEntity(name : string, value : int) = 
-    inherit TableEntity(name, String.Empty)
+    inherit RuntimeEntity(name, String.Empty, "CNT")
     member val Value = value with get, set
     new () = new CounterEntity(null, 0)
 
@@ -22,24 +27,24 @@ type LatchEntity(name : string, value : int, size : int) =
     new () = new LatchEntity(null, -1, -1)
 
 type LightCellEntity(name : string, uri : string) =
-    inherit TableEntity(name, String.Empty)
+    inherit RuntimeEntity(name, String.Empty, "CELL")
     member val Uri = uri with get, set
     new () = LightCellEntity(null, null)
 
 type ResultAggregatorEntity(name : string, index : int, bloburi : string) = 
-    inherit TableEntity(name, string index)
+    inherit RuntimeEntity(name, string index, "AGGR")
     member val Index = index with get, set
     member val Uri = bloburi with get, set
     new () = new ResultAggregatorEntity(null, -1, null)
 
 type CancellationTokenSourceEntity(id : string) =
-    inherit TableEntity(id, String.Empty)
+    inherit RuntimeEntity(id, String.Empty, "CTS")
     member val IsCancellationRequested = false with get, set
     member val Metadata = Unchecked.defaultof<string> with get, set
     new () = new CancellationTokenSourceEntity(null)
 
 type CancellationTokenLinkEntity(id : string, childId : string) =
-    inherit TableEntity(id, childId)
+    inherit RuntimeEntity(id, childId, "CTSLINK")
     new () = new CancellationTokenLinkEntity(null, null)
 
 

--- a/src/MBrace.Azure.Runtime.Common/Resources/TableStorage.fs
+++ b/src/MBrace.Azure.Runtime.Common/Resources/TableStorage.fs
@@ -10,42 +10,75 @@ open MBrace.Azure.Runtime
 // Table storage entities
 //
 // Parameterless public ctor is needed.
+[<AutoOpen>]
+module private Helper =
+    let empty = Unchecked.defaultof<string>
 
 [<AbstractClass>]
-type RuntimeEntity (pk, rk, entity) =
-    inherit TableEntity(pk, rk)
+/// Base class for all process-bound runtime resources.
+type RuntimeEntity (pid, rk, entity) =
+    inherit TableEntity(pid, rk)
     member val EntityType = entity with get, set
-
-type CounterEntity(name : string, value : int) = 
-    inherit RuntimeEntity(name, String.Empty, "CNT")
+    
+type CounterEntity(pid, name : string, value : int) = 
+    inherit RuntimeEntity(pid, name, "CNT")
     member val Value = value with get, set
-    new () = new CounterEntity(null, 0)
+    new () = new CounterEntity(empty, empty, 0)
 
-type LatchEntity(name : string, value : int, size : int) = 
-    inherit CounterEntity(name, value)
+type LatchEntity(pid, name : string, value : int, size : int) = 
+    inherit CounterEntity(pid, name, value)
     member val Size = size with get, set
-    new () = new LatchEntity(null, -1, -1)
+    new () = new LatchEntity(empty, empty, -1, -1)
 
-type LightCellEntity(name : string, uri : string) =
-    inherit RuntimeEntity(name, String.Empty, "CELL")
+type BlobReferenceEntity(pid, name : string, uri : string) =
+    inherit RuntimeEntity(pid, name, "REF")
     member val Uri = uri with get, set
-    new () = LightCellEntity(null, null)
+    new () = BlobReferenceEntity(empty, empty, empty)
+    new(pid, name) = new BlobReferenceEntity(pid, name, empty)
 
-type ResultAggregatorEntity(name : string, index : int, bloburi : string) = 
-    inherit RuntimeEntity(name, string index, "AGGR")
-    member val Index = index with get, set
-    member val Uri = bloburi with get, set
-    new () = new ResultAggregatorEntity(null, -1, null)
+// Stores around 10K CTS links.
+type CancellationTokenSourceEntity(pid, id : string, links : (string * string) list) =
+    inherit RuntimeEntity(pid, id, "CTS")
 
-type CancellationTokenSourceEntity(id : string) =
-    inherit RuntimeEntity(id, String.Empty, "CTS")
+    let split =
+        if box links <> null then
+            let s = 
+                links 
+                |> Seq.map (fun (pk, rk) -> sprintf "%s/%s" pk rk)
+                |> String.concat ";"
+            let chunkSize = 64 * 1024 * 1024 // 64KB per property
+            {0..chunkSize..s.Length-1}
+            |> Seq.map(fun i -> s.Substring(i, Math.Min(chunkSize, s.Length-i)))
+            |> Seq.toArray
+        else null
+
+    let check (a : string []) i =
+        if a = null then null else if i >= a.Length then String.Empty else a.[i]
+
     member val IsCancellationRequested = false with get, set
-    member val Metadata = Unchecked.defaultof<string> with get, set
-    new () = new CancellationTokenSourceEntity(null)
+    member val Metadata = empty with get, set
 
-type CancellationTokenLinkEntity(id : string, childId : string) =
-    inherit RuntimeEntity(id, childId, "CTSLINK")
-    new () = new CancellationTokenLinkEntity(null, null)
+    member val Link0 = check split 0 with get, set
+    member val Link1 = check split 1 with get, set
+    member val Link2 = check split 2 with get, set
+    member val Link3 = check split 3 with get, set
+    member val Link4 = check split 4 with get, set
+    member val Link5 = check split 5 with get, set
+    member val Link6 = check split 6 with get, set
+    member val Link7 = check split 7 with get, set
+    member val Link8 = check split 8 with get, set
+    member val Link9 = check split 9 with get, set
+
+    member this.GetLinks () =
+        String.Concat(
+            this.Link0, this.Link1, this.Link2, this.Link3, this.Link4, 
+            this.Link5, this.Link6, this.Link7, this.Link8, this.Link9).Split(';')
+        |> Seq.filter(not << String.IsNullOrEmpty)
+        |> Seq.map (fun pkrk -> let xs = pkrk.Split('/') in xs.[0], xs.[1])
+        |> Seq.toList
+        
+    new () = new CancellationTokenSourceEntity(empty, empty, Unchecked.defaultof<_>)
+
 
 
 module Table =
@@ -93,14 +126,29 @@ module Table =
                 |> Async.Ignore
         }
 
-    let mergeBatch<'T when 'T :> ITableEntity> config table (e : seq<'T>) : Async<unit> =
+    let mergeBatch<'T when 'T :> ITableEntity> config table (es : seq<'T>) : Async<unit> =
         async {
-            let batch = new TableBatchOperation()
-            e |> Seq.iter batch.Merge
-            let t = ConfigurationRegistry.Resolve<ClientProvider>(config).TableClient.GetTableReference(table)
-            let! _ = t.CreateIfNotExistsAsync()
-            let! _ = t.ExecuteBatchAsync(batch)
-            return ()
+
+            let jobs = new ResizeArray<Async<unit>>()
+            let batch = ref <| new TableBatchOperation()
+            let mkHandle batch = Async.StartChild <| async {
+                let t = ConfigurationRegistry.Resolve<ClientProvider>(config).TableClient.GetTableReference(table)
+                let! _ = t.CreateIfNotExistsAsync()
+                let! _ = t.ExecuteBatchAsync(batch)
+                ()
+            }
+            for e in es do
+                batch.Value.Merge(e)
+                if batch.Value.Count = 100 then
+                    let! handle = mkHandle batch.Value
+                    batch := new TableBatchOperation()
+                    jobs.Add(handle)
+            if batch.Value.Count > 0 then
+                let! handle = mkHandle batch.Value
+                jobs.Add(handle)
+
+            do! Async.Parallel jobs
+                |> Async.Ignore
         }
 
     let insertOrReplace<'T when 'T :> ITableEntity> config table (e : 'T) : Async<unit> = 
@@ -140,6 +188,22 @@ module Table =
             let rec transact e = async { 
                 f e
                 let! result = Async.Catch <| merge<'T> config table e
+                match result with
+                | Choice1Of2 r -> return r
+                | Choice2Of2 ex when PreconditionFailed ex -> 
+                    let! e = read<'T> config table pk rk
+                    return! transact e
+                | Choice2Of2 ex -> return raise ex
+            }
+            let! e = read<'T> config table pk rk
+            return! transact e
+        }
+
+    let transact2<'T when 'T :> ITableEntity> config table pk rk (f : 'T -> 'T) : Async<'T> =
+        async {
+            let rec transact e = async { 
+                let e' = f e
+                let! result = Async.Catch <| merge<'T> config table e'
                 match result with
                 | Choice1Of2 r -> return r
                 | Choice2Of2 ex when PreconditionFailed ex -> 

--- a/src/MBrace.Azure.Runtime.Common/RuntimeProvider.fs
+++ b/src/MBrace.Azure.Runtime.Common/RuntimeProvider.fs
@@ -80,4 +80,4 @@ type RuntimeProvider private (state : RuntimeState, wmon : WorkerManager, faultP
                       |> Seq.toArray 
             }
         member __.CurrentWorker = wmon.Current.AsWorkerRef() :> IWorkerRef
-        member __.Logger = state.ResourceFactory.RequestProcessLogger(psInfo.DefaultDirectory, psInfo.Id) 
+        member __.Logger = state.ResourceFactory.RequestProcessLogger(psInfo.Id) 

--- a/src/MBrace.Azure.Runtime.Common/Utils.fs
+++ b/src/MBrace.Azure.Runtime.Common/Utils.fs
@@ -25,22 +25,6 @@
             member __.ReturnFrom(f : Task) : Async<unit> =
                 __.ReturnFrom(Async.AwaitTask f)
 
-        type Uri with
-            member u.PrimaryWithScheme = sprintf "%s:%s" u.Scheme u.Primary
-            member u.SecondaryWithScheme = sprintf "%s:%s" u.Scheme u.Secondary
-
-            member u.Primary = 
-                let s = u.Segments.[0] in if s.EndsWith("/") then s.Substring(0, s.Length-1) else s
-            
-            member u.Secondary = u.Segments.[1]
-            member u.Unique = u.Segments.[2]
-
-    module Storage =
-        open MBrace.Azure.Runtime
-
-        let processIdToStorageId (pid : string) = 
-            sprintf "process%s" <| Guid.Parse(pid).ToString("N").Substring(0,7) // TODO : change
-
     type Live<'T>(provider : unit -> Async<'T>, initial : Choice<'T,exn>, ?keepLast : bool, ?interval : int, ?stopf : Choice<'T, exn> -> bool) =
         let interval = defaultArg interval 500
         let keepLast = defaultArg keepLast false

--- a/src/MBrace.Azure.Runtime/Service.fs
+++ b/src/MBrace.Azure.Runtime/Service.fs
@@ -77,7 +77,7 @@ type Service (config : Configuration, serviceId : string) =
 
                 let cfg = __.Configuration.WithAppendedId
 
-                logf "Activating Configuration %10d" cfg.Id
+                logf "Activating Configuration %010d, Hash %d" cfg.Id (hash cfg.ConfigurationId)
                 Configuration.AddIgnoredAssembly(typeof<Service>.Assembly)
                 do! Configuration.ActivateAsync(cfg)
 

--- a/src/MBrace.Azure.Runtime/Service.fs
+++ b/src/MBrace.Azure.Runtime/Service.fs
@@ -77,7 +77,7 @@ type Service (config : Configuration, serviceId : string) =
 
                 let cfg = __.Configuration.WithAppendedId
 
-                logf "Activating Configuration %010d, Hash %d" cfg.Id (hash cfg.ConfigurationId)
+                logf "Activating Configuration %05d, Hash %d" cfg.Id (hash cfg.ConfigurationId)
                 Configuration.AddIgnoredAssembly(typeof<Service>.Assembly)
                 do! Configuration.ActivateAsync(cfg)
 

--- a/src/MBrace.Azure.Runtime/Service.fs
+++ b/src/MBrace.Azure.Runtime/Service.fs
@@ -77,7 +77,7 @@ type Service (config : Configuration, serviceId : string) =
 
                 let cfg = __.Configuration.WithAppendedId
 
-                logf "Activating Configuration"
+                logf "Activating Configuration %d" cfg.Id
                 Configuration.AddIgnoredAssembly(typeof<Service>.Assembly)
                 do! Configuration.ActivateAsync(cfg)
 

--- a/src/MBrace.Azure.Runtime/Service.fs
+++ b/src/MBrace.Azure.Runtime/Service.fs
@@ -77,7 +77,7 @@ type Service (config : Configuration, serviceId : string) =
 
                 let cfg = __.Configuration.WithAppendedId
 
-                logf "Activating Configuration %d" cfg.Id
+                logf "Activating Configuration %10d" cfg.Id
                 Configuration.AddIgnoredAssembly(typeof<Service>.Assembly)
                 do! Configuration.ActivateAsync(cfg)
 

--- a/tests/MBrace.Azure.Runtime.Tests/StreamsTests.fs
+++ b/tests/MBrace.Azure.Runtime.Tests/StreamsTests.fs
@@ -3,6 +3,7 @@
 open NUnit.Framework
 open MBrace
 open MBrace.Continuation
+open MBrace.Azure
 open MBrace.Azure.Client
 open MBrace.Azure.Runtime
 open MBrace.Azure.Runtime.Standalone

--- a/tests/MBrace.Azure.Runtime.Tests/Tests.fs
+++ b/tests/MBrace.Azure.Runtime.Tests/Tests.fs
@@ -3,6 +3,7 @@
 open NUnit.Framework
 open MBrace
 open MBrace.Continuation
+open MBrace.Azure
 open MBrace.Azure.Client
 open MBrace.Azure.Runtime
 open MBrace.Azure.Runtime.Standalone

--- a/tests/MBrace.Azure.Runtime.Tests/Tests.fs
+++ b/tests/MBrace.Azure.Runtime.Tests/Tests.fs
@@ -47,12 +47,7 @@ type ``Azure Runtime Tests`` (sbus, storage) as self =
             let runtime = session.Runtime
             let cts = runtime.CreateCancellationTokenSource()
             let! ps = runtime.CreateProcessAsync(workflow cts, cancellationToken = cts.Token)
-            return! async {
-                try
-                    return! Async.Catch <| ps.AwaitResultAsync()
-                finally
-                    runtime.ClearProcess(ps.Id, true)
-            }
+            return! Async.Catch <| ps.AwaitResultAsync()
         } |> Async.RunSync
 
     override __.RunLocal(workflow : Cloud<'T>) = session.Runtime.RunLocal(workflow)

--- a/tests/MBrace.Azure.Runtime.Tests/Utils.fs
+++ b/tests/MBrace.Azure.Runtime.Tests/Utils.fs
@@ -50,7 +50,7 @@ type RuntimeSession(config : MBrace.Azure.Configuration) =
 
     member __.Start () = 
         let rt = Runtime.GetHandle(config)
-        let logger = Common.ConsoleLogger() :> ICloudLogger
+        let logger = ConsoleLogger() :> ICloudLogger
         rt.AttachClientLogger logger
         state <- Some (rt, logger)
         do System.Threading.Thread.Sleep 2000

--- a/tests/MBrace.Azure.Runtime.Tests/Utils.fs
+++ b/tests/MBrace.Azure.Runtime.Tests/Utils.fs
@@ -44,7 +44,7 @@ module Choice =
         | Choice2Of2 e -> should be instanceOfType<'Exn> e
 
 
-type RuntimeSession(config : Configuration) =
+type RuntimeSession(config : MBrace.Azure.Configuration) =
 
     let mutable state = None
 

--- a/tests/MBrace.Azure.Runtime.Tests/resources.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/resources.fsx
@@ -36,7 +36,7 @@ let clone x = Configuration.Pickler.Clone(x)
 
 //#region TaskQueue 
 
-let tq = TaskQueue.Create(config.ConfigurationId, "tempqueue", "temptopic") |> run
+let tq = JobQueue.Create(config.ConfigurationId) |> run
 
 let affinity = Guid.NewGuid().ToString "N"
 tq.Affinity <- affinity
@@ -105,7 +105,7 @@ l.Decrement() |> run
 
 l.Value
 
-let c = Blob.Create(config.ConfigurationId, fun () -> 42) |> run |> clone
+let c = Blob.CreateIfNotExists(config.ConfigurationId, "temp", "bar", fun () -> 42) |> run |> clone
 c.GetValue() |> run
 
 //#endregion

--- a/tests/MBrace.Azure.Runtime.Tests/resources.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/resources.fsx
@@ -92,10 +92,10 @@ ClientProvider.BlobClient.ListContainers("process")
 //#endregion
 
 //#region Cells
-let c = Counter.Create(config.ConfigurationId, "tmp", 1) |> run
+let c = Counter.Create(config.ConfigurationId, 1, "tmp") |> run
 c.Increment() |> run
 
-let l = Latch.Create(config.ConfigurationId, "tmp", 11) |> run
+let l = Latch.Create(config.ConfigurationId, 11, "tmp") |> run
 l.Decrement() |> run
 
 [|1..5|]
@@ -106,7 +106,7 @@ l.Decrement() |> run
 
 l.Value
 
-let c = BlobCell.Create(config.ConfigurationId, "tmp", fun () -> 42) |> run
+let c = Blob.Create(config.ConfigurationId, fun () -> 42) |> run
 c.GetValue() |> run
 
 //#endregion
@@ -136,8 +136,8 @@ let b' = Configuration.Serializer.UnPickle<Queue<int>>(b)
 //#endregion
 
 //#region Results
-let rs = ResultCell<int>.Create(config.ConfigurationId, "foobar", "temp") |> run
-
+let rs = ResultCell<int>.Create(config.ConfigurationId, "temp") |> run
+rs.Path
 async { do! Async.Sleep 10000 
         do! rs.SetResult(Result.Completed 42) }
 |> Async.Start

--- a/tests/MBrace.Azure.Runtime.Tests/resources.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/resources.fsx
@@ -31,9 +31,8 @@ let config =
 open MBrace.Azure.Runtime.Common
 open MBrace.Azure.Runtime.Resources
 let run (task : Async<'T>) = Async.RunSynchronously task
-
-//Configuration.DeleteResourcesAsync(config) |> Async.RunSynchronously
 Configuration.ActivateAsync(config) |> run
+let clone x = Configuration.Pickler.Clone(x)
 
 //#region TaskQueue 
 
@@ -92,10 +91,10 @@ ClientProvider.BlobClient.ListContainers("process")
 //#endregion
 
 //#region Cells
-let c = Counter.Create(config.ConfigurationId, 1, "tmp") |> run
+let c = Counter.Create(config.ConfigurationId, 1, "tmp") |> run |> clone
 c.Increment() |> run
 
-let l = Latch.Create(config.ConfigurationId, 11, "tmp") |> run
+let l = Latch.Create(config.ConfigurationId, 11, "tmp") |> run |> clone
 l.Decrement() |> run
 
 [|1..5|]
@@ -106,7 +105,7 @@ l.Decrement() |> run
 
 l.Value
 
-let c = Blob.Create(config.ConfigurationId, fun () -> 42) |> run
+let c = Blob.Create(config.ConfigurationId, fun () -> 42) |> run |> clone
 c.GetValue() |> run
 
 //#endregion
@@ -136,7 +135,7 @@ let b' = Configuration.Serializer.UnPickle<Queue<int>>(b)
 //#endregion
 
 //#region Results
-let rs = ResultCell<int>.Create(config.ConfigurationId, "temp") |> run
+let rs = ResultCell<int>.Create(config.ConfigurationId, "temp") |> run |> clone
 rs.Path
 async { do! Async.Sleep 10000 
         do! rs.SetResult(Result.Completed 42) }
@@ -145,7 +144,7 @@ async { do! Async.Sleep 10000
 rs.TryGetResult() |> run
 rs.AwaitResult()  |> run
 
-let ra = ResultAggregator<int>.Create(config.ConfigurationId, 10, "process000") |> run
+let ra = ResultAggregator<int>.Create(config.ConfigurationId, 10, "process000") |> run |> clone
 for x in 0..9 do
     printfn "%b" <| (run <| ra.SetResult(x, x * 10))
 ra.Complete

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -46,11 +46,11 @@ runtime.ShowProcesses()
 runtime.ShowWorkers()
 runtime.ShowLogs()
 
-runtime.ClearProcess("", true, true)
-runtime.ClearAllProcesses(true, true)
+
+
 
 let ps =
-    [1..5]
+    [1..30]
     |> Seq.map (fun i -> cloud { return i * i })
     |> Cloud.Parallel
     |> runtime.CreateProcess

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -72,14 +72,14 @@ let rec wf i max =
         else return! wf (i + 1) max <|> wf (i + 1) max
     }
 
-let ps = runtime.CreateProcess(wf 0 2)
+let ps = runtime.CreateProcess(wf 0 3)
 ps.ShowInfo()
 ps.AwaitResult() 
 
 let ct = runtime.CreateCancellationTokenSource()
 let ctask = runtime.Run(Cloud.StartAsCloudTask(cloud { return 42 }, cancellationToken = ct.Token))
-ctask.Result
 
+ctask.Result
 ctask.Id
 
 
@@ -94,7 +94,6 @@ let wf = cloud {
     let! sp, rp = CloudChannel.New<int>()
     do! cloud {
             for i = 0 to 10 do
-                do! Cloud.Sleep 1000
                 do! CloudChannel.Send(sp, i)
                 printfn "send %d" i
             return ()

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -37,7 +37,7 @@ Runtime.Spawn(config, 4, 16)
 let runtime = Runtime.GetHandle(config)
 runtime.AttachClientLogger(new ConsoleLogger()) 
 
-//runtime.Reset(false, true)
+//runtime.Reset()
 
 cloud { return 42 }
 |> runtime.Run

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -40,11 +40,12 @@ runtime.AttachClientLogger(new ConsoleLogger())
 //runtime.Reset()
 
 let ps = cloud { return 42 } |> runtime.CreateProcess
+ps.AwaitResult()
 
 runtime.ShowProcesses()
 runtime.ShowWorkers()
 runtime.ShowLogs()
-
+runtime.ClearAllProcesses(true)
 let ps =
     [1..5]
     |> Seq.map (fun i -> cloud { return i * i })

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -45,7 +45,10 @@ ps.AwaitResult()
 runtime.ShowProcesses()
 runtime.ShowWorkers()
 runtime.ShowLogs()
-runtime.ClearAllProcesses(true)
+
+runtime.ClearProcess("", true, true)
+runtime.ClearAllProcesses(true, true)
+
 let ps =
     [1..5]
     |> Seq.map (fun i -> cloud { return i * i })

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -39,9 +39,7 @@ runtime.AttachClientLogger(new ConsoleLogger())
 //runtime.Reset(reactivate = false)
 //runtime.Reset()
 
-
-cloud { return 42 }
-|> runtime.Run
+let ps = cloud { return 42 } |> runtime.CreateProcess
 
 runtime.ShowProcesses()
 runtime.ShowWorkers()

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -39,6 +39,7 @@ runtime.AttachClientLogger(new ConsoleLogger())
 
 //runtime.Reset()
 
+
 cloud { return 42 }
 |> runtime.Run
 

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -8,7 +8,7 @@
 #time "on"
 
 open MBrace
-open MBrace.Azure.Runtime
+open MBrace.Azure
 open MBrace.Azure.Client
 open System
 
@@ -27,18 +27,6 @@ let config =
         StorageConnectionString = selectEnv "azurestorageconn"
         ServiceBusConnectionString = selectEnv "azureservicebusconn" }
 
-
-#r "Microsoft.ServiceBus"
-open Microsoft.ServiceBus.Messaging
-open Microsoft.ServiceBus
-
-let q = QueueClient.CreateFromConnectionString(config.ServiceBusConnectionString, "foobar")
-let t = TopicClient.CreateFromConnectionString(config.ServiceBusConnectionString, "foobar")
-
-let ns = NamespaceManager.CreateFromConnectionString(config.ServiceBusConnectionString)
-ns.
-
-
 // local only---
 #r "MBrace.Azure.Runtime.Standalone"
 open MBrace.Azure.Runtime.Standalone
@@ -47,7 +35,7 @@ Runtime.Spawn(config, 4, 16)
 // ----------------------------
 
 let runtime = Runtime.GetHandle(config)
-runtime.AttachClientLogger(new Common.ConsoleLogger()) 
+runtime.AttachClientLogger(new ConsoleLogger()) 
 
 //runtime.Reset(false, true)
 

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -27,6 +27,18 @@ let config =
         StorageConnectionString = selectEnv "azurestorageconn"
         ServiceBusConnectionString = selectEnv "azureservicebusconn" }
 
+
+#r "Microsoft.ServiceBus"
+open Microsoft.ServiceBus.Messaging
+open Microsoft.ServiceBus
+
+let q = QueueClient.CreateFromConnectionString(config.ServiceBusConnectionString, "foobar")
+let t = TopicClient.CreateFromConnectionString(config.ServiceBusConnectionString, "foobar")
+
+let ns = NamespaceManager.CreateFromConnectionString(config.ServiceBusConnectionString)
+ns.
+
+
 // local only---
 #r "MBrace.Azure.Runtime.Standalone"
 open MBrace.Azure.Runtime.Standalone
@@ -35,7 +47,7 @@ Runtime.Spawn(config, 4, 16)
 // ----------------------------
 
 let runtime = Runtime.GetHandle(config)
-runtime.AttachLogger(new Common.ConsoleLogger()) 
+runtime.AttachClientLogger(new Common.ConsoleLogger()) 
 
 //runtime.Reset(false, true)
 

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -36,7 +36,7 @@ Runtime.Spawn(config, 4, 16)
 
 let runtime = Runtime.GetHandle(config)
 runtime.AttachClientLogger(new ConsoleLogger()) 
-
+//runtime.Reset(reactivate = false)
 //runtime.Reset()
 
 

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -48,7 +48,7 @@ runtime.ShowWorkers()
 runtime.ShowLogs()
 
 let ps =
-    [1..30]
+    [1..5]
     |> Seq.map (fun i -> cloud { return i * i })
     |> Cloud.Parallel
     |> runtime.CreateProcess

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -46,8 +46,7 @@ runtime.ShowProcesses()
 runtime.ShowWorkers()
 runtime.ShowLogs()
 
-
-
+runtime.ClearAllProcesses()
 
 let ps =
     [1..30]


### PR DESCRIPTION
# Change runtime containers and primitives

This pull request introduces changes in the places where runtime state is stored as well as changes in the layout of runtime primitives in table storage and client API changes.

## Configuration/ConfigurationId
* Configuration type has been changed to:

```fsharp
        { Id                         = 0us
          StorageConnectionString    = "connection string"
          ServiceBusConnectionString = "connection string"
          RuntimeQueue               = "MBraceQueue"
          RuntimeTopic               = "MBraceTopic"
          RuntimeContainer           = "mbraceruntimedata"
          RuntimeTable               = "MBraceRuntimeData"
          RuntimeLogsTable           = "MBraceRuntimeLogs"
          UserDataContainer          = "mbraceuserdata"
          UserDataTable              = "MBraceUserData" }
```

When using this configuration, `Configuration.Id` will be appended to all of the other settings, creating Queues/Containers: *MBraceQueue00001, MBraceRuntimeData00001*, etc. `Id` should be the same among all workers and clients, but different `Id`s can be used in order to host multiple runtimes in the same storage accounts and service bus namespaces.

## Runtime folders
In contrast with `master` the runtime will only create folders described in `Configuration`. Process-specific folders won't be created. See below for details on how runtime uses each one of those folders:

* `RuntimeTable`. This table contains most of the runtime state. Worker information and heartbeats, process information, `Counter`/`Latch`, `DistributedCancellationTokenSource`, `ResultCell` and `ResultAggregator` resources are stored here. In many cases the actual payload of a primitive is stored in blobs and only a reference is stored in this table. Most of these primitives have a human readable representation on the table. Process-specific resources are created with the process id as a `PartitionKey`.
* `RuntimeContainer`. This is a container in blob storage. Job dependencies (assemblies), as well as payload of many runtime primitives are stored here.
* `RuntimeQueue`/`RuntimeTopic`. Here is the place where all Jobs are enqueued. `RuntimeTopic` is used for Jobs with `affinity` set (e.g. `Parallel`/`StartChild` that need to be send to specific worker).
* `RuntimeLogsTable`. Runtime system logs (and client logs if configured) are stored here. The `PartitionKey` used here is the same for logs that come from the same source.
* `UserDataContainer`. This is the default container used for user data e.g. blobs created by the `CloudFile` APIs, etc.
* `UserDataTable`. This is the default table used for user data e.g. records created by the `CloudAtom` API as well as logs from `Cloud.Log`.


## Runtime resources 
* All of the runtime resources have been changed to use process id as a partition key, with the exception of the process record itself and the worker record. 
* `DistributedCancellationTokenSource` is now a single entity, `CancellationTokenSourceLinkEntity` has been removed; instead `CancellationTokenSourceEntity` holds all links.
* Jobs messages now contain process Id as a property. Message payload is written in the matching `RuntimeContainer\ProcessId` subfolder. This change can also enable faster message completion when a process is cancelled and can be used to fix some issues with process `Status` in cases of failure (not implemented). 

## API
* `Configuration` moved to from the `MBrace.Azure.Runtime` namespace to `MBrace.Azure`. Now clients only need to open `MBrace.Azure` and `MBrace.Azure.Client`.
* The client `Reset` method changed to : `Reset(?deleteQueue, ?deleteState, ?deleteLogs, ?deleteUserData, ?reactivate)`. Parameters correspond to runtime folders.
* `ClearProcess` methods now accept a `fullClean` optional parameter. This way you can specify if you want just to delete the process info record or delete all records and blobs created by the runtime for this process.