### PR TITLE
add NUnit.Runners to paket dependencies

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -100,7 +100,7 @@ let testAssemblies =
 
 Target "RunTests" (fun _ ->
     let nunitVersion = GetPackageVersion "packages" "NUnit.Runners"
-    let nunitPath = sprintf "packages/NUnit.Runners.%s/tools" nunitVersion
+    let nunitPath = "packages/NUnit.Runners/tools" 
     ActivateFinalTarget "CloseTestRunner"
 
     testAssemblies

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -14,6 +14,7 @@ nuget Microsoft.Data.Services.Client 5.6.3
 nuget Microsoft.WindowsAzure.ConfigurationManager 2.0.3
 nuget Newtonsoft.Json 6.0.6
 nuget NUnit 2.6.3
+nuget NUnit.Runners 2.6.3
 nuget System.Spatial 5.6.3
 nuget Vagabond 0.3.2
 nuget WindowsAzure.ServiceBus 2.5.2.0

--- a/paket.lock
+++ b/paket.lock
@@ -1,7 +1,7 @@
 NUGET
   remote: https://www.nuget.org/api/v2
   specs:
-    FAKE (3.18.0)
+    FAKE (3.20.0)
     FsCheck (1.0.4)
     FsPickler (1.0.13)
     FsUnit (1.3.0.1)
@@ -30,6 +30,7 @@ NUGET
     Newtonsoft.Json (6.0.6)
     NuGet.CommandLine (2.8.3)
     NUnit (2.6.3)
+    NUnit.Runners (2.6.3)
     Streams (0.2.9)
     System.Spatial (5.6.3)
     Unquote (2.2.2)


### PR DESCRIPTION
NUnit.Runners is needed, and because paket is being used the version 2.6.3 doesn't appear in the path name