### PR TITLE
Refactoring/process state

### DIFF
--- a/src/MBrace.Azure.Client/Client.fs
+++ b/src/MBrace.Azure.Client/Client.fs
@@ -196,7 +196,7 @@
                 clientLogger.Logf "Creating process %s %s" info.Id info.Name
                 do! state.AssemblyManager.UploadDependencies(dependencies)
                 clientLogger.Logf "Submit process %s." info.Id
-                let! _ = state.StartAsProcess(info, dependencies, faultPolicy, workflow, logger = clientLogger, ?ct = cancellationToken)
+                let! _ = state.StartAsProcess(info, dependencies, faultPolicy, workflow, ?ct = cancellationToken)
                 clientLogger.Logf "Created process %s." info.Id
                 let ps = Process<'T>(configuration.ConfigurationId, info.Id, pmon)
                 ProcessCache.Add(ps)

--- a/src/MBrace.Azure.Client/Process.fs
+++ b/src/MBrace.Azure.Client/Process.fs
@@ -32,7 +32,7 @@ type Process internal (config, pid : string, ty : Type, pmon : ProcessManager) =
                         | _ -> false )
 
     let logger = new ProcessLogger(config, pid)
-    let dcts = lazy DistributedCancellationTokenSource.FromPath(config, proc.Value.Id, proc.Value.CancellationUri)
+    let dcts = lazy DistributedCancellationTokenSource.FromPath(config, proc.Value.CancellationPartitionKey, proc.Value.CancellationRowKey)
 
     member internal this.ProcessEntity = proc
     member internal this.DistributedCancellationTokenSource = dcts.Value
@@ -122,7 +122,7 @@ type Process<'T> internal (config, pid : string, pmon : ProcessManager) =
     override this.AwaitResultBoxed () : obj = this.AwaitResultBoxedAsync() |> Async.RunSync 
     override this.AwaitResultBoxedAsync () : Async<obj> =
         async {
-            let rc : ResultCell<'T> = ResultCell.FromPath(config, this.ProcessEntity.Value.ResultUri)
+            let rc : ResultCell<'T> = ResultCell.FromPath(config, this.ProcessEntity.Value.Id, this.ProcessEntity.Value.ResultRowKey)
             let! r = rc.AwaitResult()
             do! this.AwaitCompletionAsync()
             return r.Value :> obj
@@ -133,7 +133,7 @@ type Process<'T> internal (config, pid : string, pmon : ProcessManager) =
     /// Asynchronously waits for the process result.
     member this.AwaitResultAsync() : Async<'T> = 
         async {
-            let rc : ResultCell<'T> = ResultCell.FromPath(config, this.ProcessEntity.Value.ResultUri)
+            let rc : ResultCell<'T> = ResultCell.FromPath(config, this.ProcessEntity.Value.Id, this.ProcessEntity.Value.ResultRowKey)
             let! r = rc.AwaitResult()
             do! this.AwaitCompletionAsync()
             return r.Value

--- a/src/MBrace.Azure.Client/Process.fs
+++ b/src/MBrace.Azure.Client/Process.fs
@@ -92,7 +92,7 @@ type Process internal (config, pid : string, ty : Type, pmon : ProcessManager) =
     member this.Kill() = Async.RunSync(this.KillAsync())
     /// Asynchronously sends a kill signal for this process.
     member this.KillAsync() = async {
-            do! pmon.SetKillRequested(pid)
+            do! pmon.SetCancellationRequested(pid)
             do this.DistributedCancellationTokenSource.Cancel()
         }
 

--- a/src/MBrace.Azure.Client/Process.fs
+++ b/src/MBrace.Azure.Client/Process.fs
@@ -25,11 +25,7 @@ type Process internal (config, pid : string, ty : Type, pmon : ProcessManager) =
     
     let proc = 
         new Live<_>((fun () -> pmon.GetProcess(pid)), initial = Choice2Of2(exn ("Process not initialized")), 
-                    keepLast = true, interval = 500, 
-                    stopf = 
-                        function 
-                        | Choice1Of2 p when p.Completed.HasValue -> p.Completed.GetValueOrDefault()
-                        | _ -> false )
+                    keepLast = true, interval = 500)
 
     let logger = new ProcessLogger(config, pid)
     let dcts = lazy DistributedCancellationTokenSource.FromPath(config, proc.Value.CancellationPartitionKey, proc.Value.CancellationRowKey)

--- a/src/MBrace.Azure.Client/Reporting.fs
+++ b/src/MBrace.Azure.Client/Reporting.fs
@@ -12,13 +12,13 @@ type internal ProcessReporter() =
     static let template : Field<ProcessRecord> list = 
         [ Field.create "Name" Left (fun p -> p.Name)
           Field.create "Process Id" Right (fun p -> p.Id)
-          Field.create "State" Right (fun p -> p.State)
+          Field.create "Status" Right (fun p -> p.State)
           Field.create "Completed" Left (fun p -> p.Completed)
           Field.create "Execution Time" Left (fun p -> if p.Completed.GetValueOrDefault() then p.CompletionTime ?-? p.InitializationTime else DateTimeOffset.UtcNow -? p.InitializationTime)
           Field.create "Jobs" Center (fun p -> sprintf "%3d / %3d / %3d / %3d"  p.ActiveJobs.Value p.FaultedJobs.Value p.CompletedJobs.Value p.TotalJobs.Value)
           Field.create "Result Type" Left (fun p -> p.TypeName) 
           Field.create "Start Time" Left (fun p -> p.InitializationTime)
-          Field.create "Completion Time" Left (fun p -> if p.Completed.GetValueOrDefault() then string p.CompletionTime else "N/A")
+          Field.create "Completion Time" Left (fun p -> p.CompletionTime )
         ]
     
     static member Report(processes : ProcessRecord seq, title, borders) = 

--- a/src/MBrace.Azure.Runtime/Execution/JobEvaluator.fs
+++ b/src/MBrace.Azure.Runtime/Execution/JobEvaluator.fs
@@ -82,8 +82,8 @@ and [<AutoSerializable(false)>]
                 logf "Cancel CancellationTokenSource %O" parentTaskCTS
                 parentTaskCTS.Cancel()
                 if jobItem.JobType = JobType.Root then
-                    logf "Setting process completed"
-                    do! staticConfiguration.State.ProcessManager.SetCompleted(jobItem.ProcessInfo.Id)
+                    logf "Setting process Faulted"
+                    do! staticConfiguration.State.ProcessManager.SetFaulted(jobItem.ProcessInfo.Id)
                 logf "Faulted message : Complete."
                 do! staticConfiguration.State.ProcessManager.AddFaultedJob(jobItem.ProcessInfo.Id)
                 do! staticConfiguration.State.JobQueue.CompleteAsync(msg)

--- a/src/MBrace.Azure.Runtime/Execution/JobEvaluator.fs
+++ b/src/MBrace.Azure.Runtime/Execution/JobEvaluator.fs
@@ -75,11 +75,11 @@ and [<AutoSerializable(false)>]
             match jobResult with
             | Choice2Of2 ex ->
                 logf "Failed to UnPickle Job :\n%A" ex
-                let parentTaskCTS = jobItem.CancellationTokenSource
-                logf "SetResult unsafe"
+                logf "SetResultUnsafe ResultCell %A" jobItem.ResultCell
                 let pk, rk = jobItem.ResultCell
                 do! ResultCell<obj>.SetResultUnsafe(jobItem.ConfigurationId, pk, rk, ex)
-                logf "Cancel CancellationTokenSource"
+                let parentTaskCTS = jobItem.CancellationTokenSource
+                logf "Cancel CancellationTokenSource %O" parentTaskCTS
                 parentTaskCTS.Cancel()
                 if jobItem.JobType = JobType.Root then
                     logf "Setting process completed"
@@ -105,7 +105,7 @@ and [<AutoSerializable(false)>]
                 | Choice2Of2 e -> 
                     do! staticConfiguration.State.JobQueue.AbandonAsync(msg)
                     do! staticConfiguration.State.ProcessManager.AddFaultedJob(job.ProcessInfo.Id)
-                    logf "Job fault %s with :\n%O" (string job) e
+                    logf "Job fault\n%s\nwith :\n%O" (string job) e
         }
 
     let pool = AppDomainEvaluatorPool.Create(

--- a/src/MBrace.Azure.Runtime/Execution/JobEvaluator.fs
+++ b/src/MBrace.Azure.Runtime/Execution/JobEvaluator.fs
@@ -61,45 +61,52 @@ and [<AutoSerializable(false)>]
         }
         Job.RunAsync provider resources faultCount job
 
-    static let run (config : JobEvaluatorConfiguration) (msg : QueueMessage) (jobItem : JobItem) = async {
-        let inline logf fmt = Printf.ksprintf (staticConfiguration.State.Logger :> ICloudLogger).Log fmt
-        try
-            do! staticConfiguration.State.AssemblyManager.LoadDependencies(jobItem.Dependencies)
-
-            logf "UnPickle Job [%d bytes]" jobItem.PickledJob.Bytes.Length
-            let job = VagabondRegistry.Instance.Pickler.UnPickleTyped(jobItem.PickledJob)
-
-            if job.JobType = JobType.Root then
-                logf "Starting Root job for Process Id : %s, Name : %s" job.ProcessInfo.Id job.ProcessInfo.Name
-                do! staticConfiguration.State.ProcessManager.SetRunning(job.ProcessInfo.Id)
-
+    static let run (config : JobEvaluatorConfiguration) (msg : QueueMessage) (jobItem : PickledJob) = 
+        async {
+            let inline logf fmt = Printf.ksprintf (staticConfiguration.State.Logger :> ICloudLogger).Log fmt
             if msg.DeliveryCount = 1 then
-                do! staticConfiguration.State.ProcessManager.AddActiveJob(job.ProcessInfo.Id)
-            
-            logf "Starting job\n%s" (string job)
-            let sw = Stopwatch.StartNew()
-            let! result = Async.Catch(runJob config job jobItem.Dependencies (msg.DeliveryCount-1))
-            sw.Stop()
+                do! staticConfiguration.State.ProcessManager.AddActiveJob(jobItem.ProcessInfo.Id)
 
-            match result with
-            | Choice1Of2 () -> 
-                do! staticConfiguration.State.JobQueue.CompleteAsync(msg)
-                do! staticConfiguration.State.ProcessManager.AddCompletedJob(job.ProcessInfo.Id)
-                logf "Completed job\n%s\nTime : %O" (string job) sw.Elapsed
-            | Choice2Of2 e -> 
-                do! staticConfiguration.State.JobQueue.AbandonAsync(msg)
-                do! staticConfiguration.State.ProcessManager.AddFaultedJob(job.ProcessInfo.Id)
-                logf "Job fault %s with :\n%O" (string job) e
-        with ex ->
-            logf "Failed to UnPickle Job :\n%A" ex
-            if msg.DeliveryCount >= 1 then
-                // TODO : Set Process as Faulted.
+            let! jobResult = Async.Catch <| async {
+                do! staticConfiguration.State.AssemblyManager.LoadDependencies(jobItem.Dependencies)
+                return jobItem.ToJob()
+            }
+
+            match jobResult with
+            | Choice2Of2 ex ->
+                logf "Failed to UnPickle Job :\n%A" ex
+                let parentTaskCTS = jobItem.CancellationTokenSource
+                logf "SetResult unsafe"
+                let pk, rk = jobItem.ResultCell
+                do! ResultCell<obj>.SetResultUnsafe(jobItem.ConfigurationId, pk, rk, ex)
+                logf "Cancel CancellationTokenSource"
+                parentTaskCTS.Cancel()
+                if jobItem.JobType = JobType.Root then
+                    logf "Setting process completed"
+                    do! staticConfiguration.State.ProcessManager.SetCompleted(jobItem.ProcessInfo.Id)
                 logf "Faulted message : Complete."
+                do! staticConfiguration.State.ProcessManager.AddFaultedJob(jobItem.ProcessInfo.Id)
                 do! staticConfiguration.State.JobQueue.CompleteAsync(msg)
-            else
-                logf "Faulted message : Abandon."
-                do! staticConfiguration.State.JobQueue.AbandonAsync(msg)
-    }
+            | Choice1Of2 job ->
+                if job.JobType = JobType.Root then
+                    logf "Starting Root job for Process Id : %s, Name : %s" job.ProcessInfo.Id job.ProcessInfo.Name
+                    do! staticConfiguration.State.ProcessManager.SetRunning(job.ProcessInfo.Id)
+
+                logf "Starting job\n%s" (string job)
+                let sw = Stopwatch.StartNew()
+                let! result = Async.Catch(runJob config job jobItem.Dependencies (msg.DeliveryCount-1))
+                sw.Stop()
+
+                match result with
+                | Choice1Of2 () -> 
+                    do! staticConfiguration.State.JobQueue.CompleteAsync(msg)
+                    do! staticConfiguration.State.ProcessManager.AddCompletedJob(job.ProcessInfo.Id)
+                    logf "Completed job\n%s\nTime : %O" (string job) sw.Elapsed
+                | Choice2Of2 e -> 
+                    do! staticConfiguration.State.JobQueue.AbandonAsync(msg)
+                    do! staticConfiguration.State.ProcessManager.AddFaultedJob(job.ProcessInfo.Id)
+                    logf "Job fault %s with :\n%O" (string job) e
+        }
 
     let pool = AppDomainEvaluatorPool.Create(
                 mkAppDomainInitializer config serviceId customLogger, 
@@ -108,6 +115,6 @@ and [<AutoSerializable(false)>]
                 maximumConcurrentDomains = 64)
 
     member __.EvaluateAsync(config : JobEvaluatorConfiguration, message : QueueMessage) = async {
-        let! jobItem = message.GetPayloadAsync<JobItem>()
+        let! jobItem = message.GetPayloadAsync<PickledJob>()
         return! pool.EvaluateAsync(jobItem.Dependencies, Async.Catch(run config message jobItem))
     }

--- a/src/MBrace.Azure.Runtime/Execution/JobEvaluator.fs
+++ b/src/MBrace.Azure.Runtime/Execution/JobEvaluator.fs
@@ -13,6 +13,7 @@ open MBrace.Azure.Runtime.Utilities
 open MBrace.Runtime.Vagabond
 open MBrace.Runtime.Store
 open Nessos.Vagabond
+open MBrace
 
 /// Default job configuration for use by JobEvaluator.
 type internal JobEvaluatorConfiguration =
@@ -77,7 +78,7 @@ and [<AutoSerializable(false)>]
                 logf "Failed to UnPickle Job :\n%A" ex
                 logf "SetResultUnsafe ResultCell %A" jobItem.ResultCell
                 let pk, rk = jobItem.ResultCell
-                do! ResultCell<obj>.SetResultUnsafe(jobItem.ConfigurationId, pk, rk, ex)
+                do! ResultCell<obj>.SetResultUnsafe(jobItem.ConfigurationId, pk, rk, new FaultException(sprintf "Failed to unpickle Job '%s'" jobItem.JobId, ex))
                 let parentTaskCTS = jobItem.CancellationTokenSource
                 logf "Cancel CancellationTokenSource %O" parentTaskCTS
                 parentTaskCTS.Cancel()

--- a/src/MBrace.Azure.Runtime/MBrace.Azure.Runtime.fsproj
+++ b/src/MBrace.Azure.Runtime/MBrace.Azure.Runtime.fsproj
@@ -92,6 +92,7 @@
     <Compile Include="RuntimeInfo\ProcessInfo.fs" />
     <Compile Include="RuntimeProvider\ResourceFactory.fs" />
     <Compile Include="RuntimeProvider\Job.fs" />
+    <Compile Include="RuntimeProvider\RuntimeState.fs" />
     <Compile Include="RuntimeProvider\Combinators.fs" />
     <Compile Include="RuntimeProvider\RuntimeProvider.fs" />
     <Compile Include="Execution\Init.fs" />

--- a/src/MBrace.Azure.Runtime/RuntimeProvider/Job.fs
+++ b/src/MBrace.Azure.Runtime/RuntimeProvider/Job.fs
@@ -315,7 +315,7 @@ with
                 match r with
                 | Result.Completed _ 
                 | Result.Exception _ -> do! pmon.SetCompleted(psInfo.Id)
-                | Result.Cancelled _ -> do! pmon.SetKilled(psInfo.Id)
+                | Result.Cancelled _ -> do! pmon.SetCancelled(psInfo.Id)
                 JobExecutionMonitor.TriggerCompletion ctx
             } |> JobExecutionMonitor.ProtectAsync ctx
 

--- a/src/MBrace.Azure.Runtime/RuntimeProvider/RuntimeState.fs
+++ b/src/MBrace.Azure.Runtime/RuntimeProvider/RuntimeState.fs
@@ -1,0 +1,210 @@
+﻿namespace MBrace.Azure.Runtime
+
+#nowarn "0444" // MBrace.Core warnings
+
+open MBrace
+open MBrace.Azure
+open MBrace.Azure.Runtime.Info
+open MBrace.Azure.Runtime.Primitives
+open MBrace.Azure.Runtime.Utilities
+open MBrace.Continuation
+open MBrace.Runtime
+open MBrace.Runtime.Utils
+open MBrace.Runtime.Vagabond
+open MBrace.Store
+open Microsoft.FSharp.Core.Printf
+open Nessos.FsPickler
+open Nessos.Vagabond
+open System
+open System.Text
+open System.Threading.Tasks
+
+[<AutoSerializable(false)>]
+/// Defines a handle to the state of a runtime instance.
+type RuntimeState =
+    {
+        /// Reference to the global job queue employed by the runtime
+        /// Queue contains pickled job and its dependencies.
+        JobQueue : JobQueue
+        /// Assembly manager.
+        AssemblyManager : BlobAssemblyManager
+        /// Reference to the runtime resource manager
+        /// Used for generating latches, cancellation tokens and result cells.
+        ResourceFactory : ResourceFactory
+        /// Process management.
+        ProcessManager : ProcessManager
+        /// Worker management.
+        WorkerManager : WorkerManager
+        /// Runtime Logger.
+        Logger : LoggerCombiner
+        /// ConfigurationId.
+        ConfigurationId : ConfigurationId
+    }
+with
+    /// Initialize a new runtime state in the local process
+    static member FromConfiguration (config : Configuration) = async {
+        let configurationId = config.ConfigurationId
+        let logger = new LoggerCombiner()
+        let! jobQueue = JobQueue.Create(configurationId, logger)
+        let assemblyManager = BlobAssemblyManager.Create(configurationId, logger) 
+        let resourceFactory = ResourceFactory.Create(configurationId) 
+        let pman = ProcessManager.Create(configurationId)
+        let wman = WorkerManager.Create(configurationId, logger)
+        return { 
+            ConfigurationId = configurationId
+            JobQueue = jobQueue
+            AssemblyManager = assemblyManager 
+            ResourceFactory = resourceFactory 
+            ProcessManager = pman
+            WorkerManager = wman
+            Logger = logger
+        }
+    }
+
+    /// <summary>
+    ///     Enqueue a batch of cloud workflows with supplied continuations to the runtime job queue.
+    ///     Used for Parallel and Choice combinators
+    /// </summary>
+    /// <param name="dependencies">Vagrant dependency manifest.</param>
+    /// <param name="cts">Distributed cancellation token source.</param>
+    /// <param name="scFactory">Success continuation factory.</param>
+    /// <param name="ec">Exception continuation.</param>
+    /// <param name="cc">Cancellation continuation.</param>
+    /// <param name="wfs">Workflows</param>
+    /// <param name="affinity">Optional job affinity.</param>
+    member internal this.EnqueueJobBatch(psInfo, dependencies, cts, fp, scFactory, ec, cc, wfs : (#Cloud<'T> * IWorkerRef option) [], distribType : DistributionType, parentJobId, resultCell) : Async<unit> =
+        async {
+            let jobs = Array.zeroCreate wfs.Length
+            for i = 0 to wfs.Length - 1 do
+                let jobId = guid()
+                let wf = fst wfs.[i]
+                let affinity = match snd wfs.[i] with Some wr -> Some wr.Id | None -> None
+                let stathisJob ctx =
+                    let cont = { Success = scFactory i ; Exception = ec ; Cancellation = cc }
+                    Cloud.StartWithContinuations(wf, cont, ctx)
+                let jobType aff =
+                    match distribType, aff with
+                    | Parallel, Some a -> ParallelAffined(a, i, wfs.Length-1)
+                    | Choice, Some a   -> ChoiceAffined(a, i, wfs.Length-1)
+                    | Parallel, None   -> JobType.Parallel(i,wfs.Length-1)
+                    | Choice, None     -> JobType.Choice(i,wfs.Length-1)
+
+                let pickle value = VagabondRegistry.Instance.Pickler.PickleTyped(value)
+
+                let job = 
+                    { 
+                        ConfigurationId         = this.ConfigurationId
+                        PickledType             = pickle typeof<'T>
+                        ProcessInfo             = psInfo
+                        JobId                   = jobId
+                        PickledStartJob         = pickle stathisJob
+                        CancellationTokenSource = cts
+                        PickledFaultPolicy      = pickle fp
+                        PickledEcont            = pickle ec
+                        JobType                 = jobType affinity
+                        ParentJobId             = parentJobId
+                        Dependencies            = dependencies
+                        ResultCell              = resultCell
+                    }
+                jobs.[i] <- job, affinity
+            do! this.JobQueue.EnqueueBatch<PickledJob>(jobs, pid = psInfo.Id)
+            do! this.ProcessManager.IncreaseTotalJobs(psInfo.Id, jobs.Length)
+        }
+
+    member private this.EnqueueJob(psInfo, jobId, dependencies, cts, fp, sc, ec, cc, wf : Cloud<'T>, jobType : JobType, parentJobId, resultCell) : Async<unit> =
+        async {
+            let startJob ctx =
+                let cont = { Success = sc ; Exception = ec ; Cancellation = cc }
+                Cloud.StartWithContinuations(wf, cont, ctx)
+            let affinity = match jobType with Affined a -> Some a | _ -> None
+            let pickle value = VagabondRegistry.Instance.Pickler.PickleTyped(value)
+
+            let job = 
+                { 
+                    ConfigurationId         = this.ConfigurationId
+                    PickledType             = pickle typeof<'T>
+                    ProcessInfo             = psInfo
+                    JobId                   = jobId
+                    PickledStartJob         = pickle startJob
+                    CancellationTokenSource = cts
+                    PickledFaultPolicy      = pickle fp
+                    PickledEcont            = pickle ec
+                    JobType                 = jobType 
+                    ParentJobId             = parentJobId
+                    Dependencies            = dependencies
+                    ResultCell              = resultCell
+                }
+
+            this.Logger.Logf "Job Enqueue."
+            do! this.JobQueue.Enqueue<PickledJob>(job, ?affinity = affinity, pid = psInfo.Id)
+            this.Logger.Logf "Job Enqueue completed."
+            do! this.ProcessManager.IncreaseTotalJobs(psInfo.Id)
+        }
+
+    /// Schedules a cloud workflow as an ICloudTask.
+    member internal this.StartAsTask(psInfo : ProcessInfo, dependencies, cts, fp, wf : Cloud<'T>, jobType, parentJobId) : Async<ICloudTask<'T>> = async {
+        let jobId = guid()
+        let! resultCell = async {
+            let batch = this.ResourceFactory.GetResourceBatchForProcess(psInfo.Id)
+            let rc = batch.RequestResultCell(jobId)
+            do! batch.CommitAsync()
+            return rc
+        }
+        let setResult ctx r = 
+            async {
+                do! resultCell.SetResult r
+                JobExecutionMonitor.TriggerCompletion ctx
+            } |> JobExecutionMonitor.ProtectAsync ctx
+            
+        let scont ctx t = setResult ctx (Result.Completed t)
+        let econt ctx e = setResult ctx (Result.Exception e)
+        let ccont ctx c = setResult ctx (Result.Cancelled c)
+        do! this.EnqueueJob(psInfo, jobId, dependencies, cts, fp, scont, econt, ccont, wf, jobType, parentJobId, (resultCell.PartitionKey, resultCell.RowKey))
+        return resultCell :> ICloudTask<'T>
+    }
+
+    /// Schedules a cloud workflow as an ICloudJob.
+    /// Used for root-level workflows.
+    member this.StartAsProcess(psInfo : ProcessInfo, dependencies, fp, wf : Cloud<'T>, ?ct : ICloudCancellationToken) = async {
+        let jobId = guid ()
+        
+        this.Logger.Logf "Request for CancellationTokenSource"
+        let! cts = 
+            match ct with
+            | None -> this.ResourceFactory.RequestCancellationTokenSource(psInfo.Id, metadata = jobId, elevate = true)
+            | Some ct -> async { return ct :?> DistributedCancellationTokenSource }
+        
+        let requests = this.ResourceFactory.GetResourceBatchForProcess(psInfo.Id)
+        let resultCell = requests.RequestResultCell<'T>(jobId)
+        this.Logger.Logf "Creating Process Record for %s" psInfo.Id
+        do! Async.Parallel [| this.ProcessManager.CreateRecord(psInfo.Id, psInfo.Name, typeof<'T>, dependencies, cts, resultCell.RowKey)
+                              requests.CommitAsync() |]
+            |> Async.Ignore
+
+        let setResult ctx r = 
+            async {
+                do! resultCell.SetResult r
+                let pmon = ctx.Resources.Resolve<ProcessManager>()
+                match r with
+                | Result.Completed _ 
+                | Result.Exception _ -> do! pmon.SetCompleted(psInfo.Id)
+                | Result.Cancelled _ -> do! pmon.SetCancelled(psInfo.Id)
+                JobExecutionMonitor.TriggerCompletion ctx
+            } |> JobExecutionMonitor.ProtectAsync ctx
+
+        let scont ctx t = setResult ctx (Result.Completed t)
+        let econt ctx e = setResult ctx (Result.Exception e)
+        let ccont ctx c = setResult ctx (Result.Cancelled c)
+
+        try
+            do! this.EnqueueJob(psInfo, jobId, dependencies, cts, fp, scont, econt, ccont, wf, JobType.Root, String.Empty, (resultCell.PartitionKey, resultCell.RowKey))
+            return resultCell
+        with ex ->
+            this.Logger.Logf "Failed to post process %s. Cleanup." psInfo.Id
+            do! this.ProcessManager.ClearProcess(psInfo.Id, true, true)
+            return! Async.Raise ex
+    }
+
+    /// Attempt to dequeue a job from the runtime job queue.
+    member this.TryDequeue () : Async<QueueMessage option> =
+        async { return! this.JobQueue.TryDequeue() }

--- a/tests/MBrace.Azure.Runtime.Tests/StreamsTests.fs
+++ b/tests/MBrace.Azure.Runtime.Tests/StreamsTests.fs
@@ -52,7 +52,7 @@ type ``Streams Standalone - Storage Emulator`` () =
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
         Runtime.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        Runtime.SpawnLocal(base.Configuration, 4) 
+        Runtime.SpawnLocal(base.Configuration, 16) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]
@@ -68,7 +68,7 @@ type ``Streams Standalone`` () =
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
         Runtime.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        Runtime.SpawnLocal(base.Configuration, 4) 
+        Runtime.SpawnLocal(base.Configuration, 16) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]

--- a/tests/MBrace.Azure.Runtime.Tests/Tests.fs
+++ b/tests/MBrace.Azure.Runtime.Tests/Tests.fs
@@ -116,7 +116,7 @@ type ``Standalone - Storage Emulator`` () =
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
         Runtime.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        Runtime.SpawnLocal(base.Configuration, 16) 
+        Runtime.SpawnLocal(base.Configuration, 4, 16) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]
@@ -132,7 +132,7 @@ type ``Standalone`` () =
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
         Runtime.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        Runtime.SpawnLocal(base.Configuration, 16) 
+        Runtime.SpawnLocal(base.Configuration, 4, 16) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]

--- a/tests/MBrace.Azure.Runtime.Tests/Tests.fs
+++ b/tests/MBrace.Azure.Runtime.Tests/Tests.fs
@@ -116,7 +116,7 @@ type ``Standalone - Storage Emulator`` () =
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
         Runtime.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        Runtime.SpawnLocal(base.Configuration, 4) 
+        Runtime.SpawnLocal(base.Configuration, 16) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]
@@ -132,7 +132,7 @@ type ``Standalone`` () =
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
         Runtime.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        Runtime.SpawnLocal(base.Configuration, 4) 
+        Runtime.SpawnLocal(base.Configuration, 16) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -51,6 +51,18 @@ ps.AwaitResult()
 ps.Kill()
 
 
+let wf = 
+    cloud {
+        let! ct = Cloud.CreateCancellationTokenSource()
+        let! t = Cloud.StartAsCloudTask(cloud { return 42 }, cancellationToken = ct.Token)
+        return! Cloud.Catch(t.AwaitResult())
+    }
+
+let ps = runtime.CreateProcess(wf)
+ps.AwaitResult()
+ps.ShowInfo()
+
+
 let ps () = 
  cloud { let tasks = new ResizeArray<_>()
          for i in [ 0 .. 200 ] do 

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -38,7 +38,6 @@ runtime.AttachClientLogger(new ConsoleLogger())
 Runtime.SpawnLocal(config, 4, 16)
 // ----------------------------
 
-
 runtime.ShowProcesses()
 runtime.ShowWorkers()
 runtime.ShowLogs()


### PR DESCRIPTION
This PR contains several improvements on process status:
* Processes that failed to submit, no longer remain `Posted`.
* Deserialization or assembly loading errors, not longer leave the process or task `Running`. Instead the exception will be wrapped to a `FaultException` and is set as the result of the parent task or process. This will Fix #38.
* Added a `Faulted` process status for unrecoverable errors (like the one above).
* Fixed an issue where the client showed inaccurate status for completed processes with pending jobs (like `Choice` etc).