### PR TITLE
WorkerRef refactoring

### DIFF
--- a/src/MBrace.Azure.Runtime/Execution/JobEvaluator.fs
+++ b/src/MBrace.Azure.Runtime/Execution/JobEvaluator.fs
@@ -83,6 +83,7 @@ and [<AutoSerializable(false)>]
     static let run (config : JobEvaluatorConfiguration) (msg : QueueMessage) (dependencies : VagabondAssembly list) (jobItem : PickledJob) = 
         async {
             let inline logf fmt = Printf.ksprintf (staticConfiguration.State.Logger :> ICloudLogger).Log fmt
+
             if msg.DeliveryCount = 1 then
                 do! staticConfiguration.State.ProcessManager.AddActiveJob(jobItem.ProcessInfo.Id)
 
@@ -103,6 +104,7 @@ and [<AutoSerializable(false)>]
                     do! staticConfiguration.State.ProcessManager.SetRunning(job.ProcessInfo.Id)
 
                 logf "Starting job\n%s" (string job)
+                logf "Delivery count : %d" msg.DeliveryCount
                 let sw = Stopwatch.StartNew()
                 let! result = Async.Catch(runJob config job jobItem.Dependencies (msg.DeliveryCount-1))
                 sw.Stop()

--- a/src/MBrace.Azure.Runtime/RuntimeInfo/WorkerInfo.fs
+++ b/src/MBrace.Azure.Runtime/RuntimeInfo/WorkerInfo.fs
@@ -116,7 +116,7 @@ type WorkerRef internal (config : ConfigurationId, partitionKey, rowKey) =
             (fun () -> Table.read config config.RuntimeTable partitionKey rowKey),
             Choice1Of2(record),
             keepLast = false,
-            interval = 500,
+            interval = 1000,
             stopf = fun _ -> not enableUpdates)
       
     let getRecord() =

--- a/src/MBrace.Azure.Runtime/RuntimeProvider/RuntimeProvider.fs
+++ b/src/MBrace.Azure.Runtime/RuntimeProvider/RuntimeProvider.fs
@@ -85,5 +85,7 @@ type RuntimeProvider private (state : RuntimeState, job : Job, dependencies, isF
             return ws |> Seq.map (fun w -> w :> IWorkerRef)
                       |> Seq.toArray 
             }
-        member __.CurrentWorker = state.WorkerManager.Current.AsWorkerRef() :> IWorkerRef
+        member __.CurrentWorker =
+            let w = state.WorkerManager.Current
+            new MBrace.Azure.WorkerRef(Configuration.Pickler.UnPickle(w.ConfigurationId) ,w.PartitionKey, w.RowKey) :> IWorkerRef
         member __.Logger = state.ResourceFactory.RequestProcessLogger(job.ProcessInfo.Id) 

--- a/src/MBrace.Azure.Runtime/Utilities/Utils.fs
+++ b/src/MBrace.Azure.Runtime/Utilities/Utils.fs
@@ -61,6 +61,7 @@
         let interval = defaultArg interval 500
         let keepLast = defaultArg keepLast false
         let stopf = defaultArg stopf (fun _ -> false)
+        let mutable stop = false
         let mutable value = initial
 
         let runOnce () = async {
@@ -74,7 +75,7 @@
 
         let rec update () = async {
             let! choice = runOnce()
-            if stopf choice then 
+            if stopf choice || stop then 
                 return ()
             else
                 do! Async.Sleep interval
@@ -93,6 +94,9 @@
             match value with
             | Choice1Of2 v -> v
             | Choice2Of2 e -> raise e
+
+        member __.Stop () = stop <- true
+            
 
 
     [<RequireQualifiedAccess>]

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -44,26 +44,12 @@ runtime.ShowProcesses()
 runtime.ShowWorkers()
 runtime.ShowLogs()
 
+
 let ps =
     cloud {
         let client = new System.Net.WebClient()
         return! Cloud.Parallel [| cloud { return client } |]
     } |> runtime.CreateProcess
-
-
-
-
-#r "Streams.Core.dll"
-#r "MBrace.Flow.dll"
-
-open MBrace.Flow
-
-let wf = 
-    [|1..10|]
-    |> CloudFlow.OfArray
-    |> CloudFlow.map (fun i -> i * i)
-    |> CloudFlow.toArray
-    |> runtime.Run
 
 let files = runtime.StoreClient.File.Enumerate "wiki" 
 let paths = files |> Array.map (fun file -> file.Path)

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -31,12 +31,10 @@ let config =
         ServiceBusConnectionString = selectEnv "azureservicebusconn" }
 
 let runtime = Runtime.GetHandle(config)
-runtime.Reset(true, true, true, true, true)
 runtime.AttachClientLogger(new ConsoleLogger())
+//runtime.Reset(true, true, true, true, false)
 //runtime.Reset(reactivate = false)
 //runtime.Reset()
-
-runtime.ShowWorkers()
 
 // local only---
 runtime.AttachLocalWorker(4, 16)
@@ -45,6 +43,15 @@ runtime.AttachLocalWorker(4, 16)
 runtime.ShowProcesses()
 runtime.ShowWorkers()
 runtime.ShowLogs()
+
+let ps =
+    cloud {
+        let client = new System.Net.WebClient()
+        return! Cloud.Parallel [| cloud { return client } |]
+    } |> runtime.CreateProcess
+
+
+
 
 #r "Streams.Core.dll"
 #r "MBrace.Flow.dll"


### PR DESCRIPTION
Minor WorkerRef refactoring.
* Replaced the WorkerRef record with a class.
* WorkerRef now has a `AutoUpdate` property (turned off by default) that enables automatic updates on the WorkerRef properties. Still, if you need to do this for all workers, using GetWorkers again (without autoupdate) is a better option.