### PR TITLE
Configuration refactoring

### DIFF
--- a/samples/MBrace.Azure.CloudService.WorkerRole/WorkerRole.cs
+++ b/samples/MBrace.Azure.CloudService.WorkerRole/WorkerRole.cs
@@ -38,9 +38,7 @@ namespace MBrace.Azure.CloudService.WorkerRole
 
             bool result = base.OnStart();
 
-            _config = Configuration.Default
-                        .WithStorageConnectionString(CloudConfigurationManager.GetSetting("MBrace.StorageConnectionString"))
-                        .WithServiceBusConnectionString(CloudConfigurationManager.GetSetting("MBrace.ServiceBusConnectionString"));
+            _config = new Configuration(CloudConfigurationManager.GetSetting("MBrace.StorageConnectionString"), CloudConfigurationManager.GetSetting("MBrace.ServiceBusConnectionString"));
             _svc = 
                 RoleEnvironment.IsEmulated ? 
                 new Service(_config) : // Avoid long service names when using emulator
@@ -68,9 +66,7 @@ namespace MBrace.Azure.CloudService.WorkerRole
                 if (item.ConfigurationSettingName == "MBrace.ServiceBusConnectionString"
                     || item.ConfigurationSettingName == "MBrace.StorageConnectionString")
                 {
-                    _config = Configuration.Default
-                                .WithStorageConnectionString(CloudConfigurationManager.GetSetting("MBrace.StorageConnectionString"))
-                                .WithServiceBusConnectionString(CloudConfigurationManager.GetSetting("MBrace.ServiceBusConnectionString"));
+                    _config = new Configuration(CloudConfigurationManager.GetSetting("MBrace.StorageConnectionString"), CloudConfigurationManager.GetSetting("MBrace.ServiceBusConnectionString"));
                     _svc.Stop();
                     _svc.Configuration = _config;
                     _svc.Start();

--- a/src/MBrace.Azure.Client/Client.fs
+++ b/src/MBrace.Azure.Client/Client.fs
@@ -198,9 +198,10 @@ type MBraceAzure private (manager : RuntimeManager, defaultLogger : StorageSyste
     /// <param name="deleteLogs">Delete Configuration logs table.</param>
     /// <param name="deleteUserData">Delete Configuration UserData table and container.</param>
     /// <param name="force">Ignore active workers.</param>
+    /// <param name="reactivate">Reactivate configuration.</param>
     [<CompilerMessage("Using 'Reset' may cause unexpected behavior in clients and workers.", 445)>]
-    member this.Reset(deleteQueues, deleteState, deleteLogs, deleteUserData, force) =
-        manager.ResetCluster(deleteQueues, deleteState, deleteLogs, deleteUserData, force)
+    member this.Reset(deleteQueues, deleteState, deleteLogs, deleteUserData, force, reactivate) =
+        manager.ResetCluster(deleteQueues, deleteState, deleteLogs, deleteUserData, force, reactivate)
         |> Async.RunSync
 
     /// <summary>

--- a/src/MBrace.Azure.Runtime/Common/Config.fs
+++ b/src/MBrace.Azure.Runtime/Common/Config.fs
@@ -1,15 +1,8 @@
-﻿namespace MBrace.Azure
-
-open Microsoft.ServiceBus
-open Microsoft.WindowsAzure.Storage
-open System.Security.Cryptography
-open System.Text
-open System
+﻿namespace MBrace.Azure.Runtime
 
 /// Configuration identifier.
 [<AutoSerializable(true)>]
 type ConfigurationId =
-    private
       { /// Runtime identifier.
         Id : uint16
         /// Runtime version string
@@ -33,138 +26,97 @@ type ConfigurationId =
         /// User data table prefix.
         UserDataTable : string }
 
+namespace MBrace.Azure
 
-/// Azure specific Runtime Configuration.
+open Microsoft.ServiceBus
+open Microsoft.WindowsAzure.Storage
+open System.Security.Cryptography
+open System.Text
+open System
+open MBrace.Azure.Runtime
+open MBrace.Runtime.Utils.String
+
+// Make this serializable for client/local runtime communication.
 [<AutoSerializable(true)>]
-type Configuration =
-    { /// Runtime identifier.
-      Id : uint16
-      /// Runtime version string.
-      Version : string
-      /// Azure storage connection string.
-      StorageConnectionString : string
-      /// Service Bus connection string.
-      ServiceBusConnectionString : string
-      /// Service Bus Queue prefix.
-      RuntimeQueue : string
-      /// Service Bus Topic prefix.
-      RuntimeTopic : string
-      /// Runtime blob container prefix.
-      RuntimeContainer : string
-      /// Runtime table prefix.
-      RuntimeTable : string
-      /// Runtime logs table prefix.
-      RuntimeLogsTable : string
-      /// User data container prefix.
-      UserDataContainer : string
-      /// User data table prefix.
-      UserDataTable : string
-    }
+/// MBrace.Azure runtime configuration.
+type Configuration(storageConnectionString : string, serviceBusConnectionString : string) = 
 
-    /// Returns an Azure Configuration with the default values.
-    static member Default =
-        { Id                         = 0us
-          Version                    = typeof<Configuration>.Assembly.GetName().Version.ToString(4)
-          StorageConnectionString    = "your connection string"
-          ServiceBusConnectionString = "your connection string"
-          // See Azure/ServiceBus name limits
-          RuntimeQueue               = "MBraceQueue"
-          RuntimeTopic               = "MBraceTopic"
-          RuntimeContainer           = "mbraceruntimedata"
-          RuntimeTable               = "MBraceRuntimeData"
-          RuntimeLogsTable           = "MBraceRuntimeLogs"
-          UserDataContainer          = "mbraceuserdata"
-          UserDataTable              = "MBraceUserData" }
+    /// Runtime identifier, used for runtime isolation when using the same storage/servicebus accounts. Defaults to 0.
+    member val Id                         = 0us with get, set
 
+    /// Runtime version this configuration is targeting. Default to current assembly version.
+    member val Version                    = typeof<Configuration>.Assembly.GetName().Version.ToString(4) with get, set
 
-    /// Append Configuration.Id on all values.
-    /// Note : This property should not be used by clients.
-    member this.WithAppendedId =
-        let version, versionString =
+    /// Azure Storage connection string.
+    member val StorageConnectionString    = storageConnectionString with get, set
+
+    /// Azure Service Bus connection string.
+    member val ServiceBusConnectionString = serviceBusConnectionString with get, set
+
+    /// Service Bus queue used by the runtime.
+    member val RuntimeQueue               = "MBraceQueue" with get, set
+
+    /// Service Bus topic used by the runtime.
+    member val RuntimeTopic               = "MBraceTopic" with get, set
+
+    /// Azure Storage container used by the runtime.
+    member val RuntimeContainer           = "mbraceruntimedata" with get, set
+
+    /// Azure Storage table used by the runtime.
+    member val RuntimeTable               = "MBraceRuntimeData" with get, set
+
+    /// Azure Storage table used by the runtime for storing logs.
+    member val RuntimeLogsTable           = "MBraceRuntimeLogs" with get, set
+
+    /// Azure Storage container used for user data.
+    member val UserDataContainer          = "mbraceuserdata" with get, set
+
+    /// Azure Storage table used for user data.
+    member val UserDataTable              = "MBraceUserData" with get, set
+    
+    /// Append version to given configuration e.g. $RuntimeQueue$Version. Defaults to true.
+    member val UseVersionPostfix          = true with get, set
+
+    /// Append runtime id to given configuration e.g. $RuntimeQueue$Version$Id. Defaults to true.
+    member val UseIdPostfix               = true with get, set
+
+    /// Validate configuration and construct ConfigurationId.
+    member this.GetConfigurationId () : ConfigurationId = 
+        let versionNormalized, versionPostfix =
             match Version.TryParse(this.Version) with
-            | true, v  -> v, sprintf "%dx%dx%dx%d" v.Major v.Minor v.Build v.Revision
-            | false, _ -> failwith <| sprintf "Invalid Version string '%s'" this.Version
+            | true, v  -> v.ToString(4), sprintf "%dx%dx" v.Major v.Minor
+            | false, _ -> raise <| InvalidConfigurationException(sprintf "Invalid Version string '%s'" this.Version)
+        
+        let appendId text =
+            if this.UseIdPostfix then sprintf "%s%05d" text this.Id else text
+        let appendVersionAndId (text : string) =
+            let sb = new StringBuilder()
+            (stringB {
+                yield text
+                if this.UseVersionPostfix then yield versionPostfix
+                if this.UseIdPostfix then yield sprintf "%05d" this.Id
+            }) sb
+            sb.ToString()
 
-        let versionNormalized = version.ToString(4)
-
-        let withVersionAndId s =
-            // TODO : Temporary fix to enable GetHandle from newer clients.
-            // 0.6.5 clients do not use Version in folder names.
-            // < 0.6.1 clients have complete different folder structure.
-            if version <= Version(0, 6, 1, 0) then
-                raise(NotSupportedException("Connecting to runtimes with Version <= 0.6.1 not supported from newer clients. Use a client with the same version instead."))
-            elif version < Version(0, 6, 5, 0) then
-                sprintf "%s%05d" s this.Id
-            else
-                sprintf "%s%s%05d" s versionString this.Id
-
-        let withId s =sprintf "%s%05d" s this.Id
-
-        { this with
-            Version = versionNormalized
-            RuntimeQueue = withVersionAndId this.RuntimeQueue
-            RuntimeTopic = withVersionAndId this.RuntimeTopic
-            RuntimeContainer = withVersionAndId this.RuntimeContainer
-            RuntimeTable = withVersionAndId this.RuntimeTable
-            RuntimeLogsTable = withVersionAndId this.RuntimeLogsTable
-            UserDataContainer = withId this.UserDataContainer
-            UserDataTable = withId this.UserDataTable
-        }
-
-    /// Configuration identifier hash.
-    member this.ConfigurationId : ConfigurationId =
         let hashAlgorithm = SHA256Managed.Create()
         let getHash(txt : string) = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes txt)
 
         let store = CloudStorageAccount.Parse(this.StorageConnectionString).Credentials.AccountName
         let sbus = NamespaceManager.CreateFromConnectionString(this.ServiceBusConnectionString).Address.ToString()
 
-        { Id = this.Id
-          Version = this.Version
-          StorageConnectionStringHash = getHash store
-          ServiceBusConnectionStringHash = getHash sbus
-          RuntimeQueue = this.RuntimeQueue.ToLower()
-          RuntimeTopic = this.RuntimeTopic.ToLower()
-          RuntimeContainer = this.RuntimeContainer.ToLower()
-          RuntimeTable = this.RuntimeTable.ToLower()
-          RuntimeLogsTable = this.RuntimeLogsTable.ToLower()
-          UserDataContainer = this.UserDataContainer.ToLower()
-          UserDataTable = this.UserDataTable.ToLower()
+        {
+            Id                             = this.Id
+            Version                        = versionNormalized
+            StorageConnectionStringHash    = getHash store
+            ServiceBusConnectionStringHash = getHash sbus
+            RuntimeQueue                   = (appendVersionAndId this.RuntimeQueue    ).ToLower()
+            RuntimeTopic                   = (appendVersionAndId this.RuntimeTopic    ).ToLower()
+            RuntimeContainer               = (appendVersionAndId this.RuntimeContainer).ToLower()
+            RuntimeTable                   = (appendVersionAndId this.RuntimeTable    ).ToLower()
+            RuntimeLogsTable               = (appendVersionAndId this.RuntimeLogsTable).ToLower()
+            UserDataContainer              = (appendId this.UserDataContainer         ).ToLower()
+            UserDataTable                  = (appendId this.UserDataTable             ).ToLower()
         }
-
-    /// Return a new copy with altered Version.
-    member this.WithVersion(version : string) =
-        { this with Version = version }
-
-    /// Return a new copy with altered Id.
-    member this.WithId(id) =
-        { this with Id = id }
-
-
-    /// Return a new copy with altered the default user data folders.
-    member this.WithUserDataFolders(userDataContainer, userDataTable) =
-        { this with
-            UserDataContainer = userDataContainer
-            UserDataTable = userDataTable }
-
-    /// Return a new copy with altered runtime Queues, Containers and Tables.
-    member this.WithRuntimeFolders(runtimeQueue, runtimeTopic, runtimeContainer, runtimeTable, runtimeLogsTable, userDataContainer, userDataTable) =
-        { this with
-            RuntimeQueue      = runtimeQueue
-            RuntimeTopic      = runtimeTopic
-            RuntimeContainer  = runtimeContainer
-            RuntimeTable      = runtimeTable
-            RuntimeLogsTable  = runtimeLogsTable
-            UserDataContainer = userDataContainer
-            UserDataTable     = userDataTable }
-
-    /// Return a new copy with altered storage connection string.
-    member this.WithStorageConnectionString(conn : string) =
-        { this with StorageConnectionString = conn }
-
-    /// Return a new copy with altered service bus connection string.
-    member this.WithServiceBusConnectionString(conn : string) =
-        { this with ServiceBusConnectionString = conn }
 
 namespace MBrace.Azure.Runtime
 
@@ -312,7 +264,7 @@ type Config private () =
         initialize populateDirs
         let cp = new StoreClientProvider(config)
         do! cp.InitAll()
-        ConfigurationRegistry.Register<StoreClientProvider>(config.ConfigurationId, cp)
+        ConfigurationRegistry.Register<StoreClientProvider>(config.GetConfigurationId(), cp)
     }
 
     /// Activates the given configuration.

--- a/src/MBrace.Azure.Runtime/Common/Config.fs
+++ b/src/MBrace.Azure.Runtime/Common/Config.fs
@@ -1,6 +1,9 @@
 ﻿namespace MBrace.Azure.Runtime
 
+open System
+
 /// Configuration identifier.
+/// Holds hashes of connection strings and normalized runtime folders.
 [<AutoSerializable(true)>]
 type ConfigurationId =
       { /// Runtime identifier.
@@ -11,20 +14,40 @@ type ConfigurationId =
         StorageConnectionStringHash : byte []
         /// Service Bus connection string hash.
         ServiceBusConnectionStringHash : byte []
-        /// Service Bus Queue prefix.
+        /// Service Bus Queue.
         RuntimeQueue : string
-        /// Service Bus Topic prefix.
+        /// Service Bus Topic.
         RuntimeTopic : string
-        /// Runtime blob container prefix.
+        /// Runtime blob container.
         RuntimeContainer : string
-        /// Runtime table prefix.
+        /// Runtime table.
         RuntimeTable : string
-        /// Runtime logs table prefix.
+        /// Runtime logs table.
         RuntimeLogsTable : string
-        /// User data container prefix.
+        /// User data container.
         UserDataContainer : string
-        /// User data table prefix.
+        /// User data table.
         UserDataTable : string }
+    with
+        interface MBrace.Runtime.IRuntimeId with
+            member this.Id: string = 
+                let toBytes (text : string) = System.Text.Encoding.UTF8.GetBytes(text)
+                [
+                    this.Id |> sprintf "%05d" |> toBytes
+                    this.Version              |> toBytes
+                    this.StorageConnectionStringHash
+                    this.ServiceBusConnectionStringHash
+                    this.RuntimeQueue      + ";" |> toBytes
+                    this.RuntimeTopic      + ";" |> toBytes
+                    this.RuntimeContainer  + ";" |> toBytes
+                    this.RuntimeTable      + ";" |> toBytes
+                    this.RuntimeLogsTable  + ";" |> toBytes
+                    this.UserDataContainer + ";" |> toBytes
+                    this.UserDataTable     + ";" |> toBytes
+                ] 
+                |> Array.concat
+                |> Convert.ToBase64String
+            
 
 namespace MBrace.Azure
 

--- a/src/MBrace.Azure.Runtime/Common/Validation.fs
+++ b/src/MBrace.Azure.Runtime/Common/Validation.fs
@@ -1,0 +1,50 @@
+﻿namespace MBrace.Azure.Runtime
+
+[<RequireQualifiedAccess>]
+module Validate =
+    open Microsoft.WindowsAzure.Storage
+    open Microsoft.ServiceBus
+
+    // http://blogs.msdn.com/b/jmstall/archive/2014/06/12/azure-storage-naming-rules.aspx
+
+    let private lower = set { 'a'..'z' }
+    let private upper = set { 'A'..'Z' }
+    let private alpha = lower + upper
+    let private number = set { '0'..'9' }
+    let private alphanumeric = alpha + number
+
+    let storageConn conn =
+        match CloudStorageAccount.TryParse(conn) with
+        | true, _ -> ()
+        | false, _ -> raise(InvalidConfigurationException(sprintf "Invalid Storage connection string %A" conn))
+        conn
+
+    let serviceBusConn conn =
+        try
+            NamespaceManager.CreateFromConnectionString(conn).QueueExists("foobar")
+            |> ignore
+        with ex -> raise(InvalidConfigurationException(sprintf "Invalid ServiceBus connection string %A" conn, ex))
+        conn
+
+    let tableName (name : string) =
+        let exn = InvalidConfigurationException(sprintf "Invalid table name %A. See Azure Table Storage naming rules." name)
+        if name.Length < 3 || name.Length > 63 then raise exn
+        if name |> Seq.forall alphanumeric.Contains |> not then raise exn
+        name
+
+    let containerName (name : string) = 
+        let exn = InvalidConfigurationException(sprintf "Invalid container name %A. See Azure Blob Storage naming rules." name)
+        if name.Length < 3 || name.Length > 63 then raise exn
+        if name |> Seq.forall (lower + number).Contains |> not then raise exn
+        name
+
+    let queueName (name : string) = 
+        let exn = InvalidConfigurationException(sprintf "Invalid queue name %A. See Azure Service Bus naming rules." name)
+        if name |> Seq.forall (alphanumeric + set ['-'; '_'; '/']).Contains |> not then raise exn
+        name
+                
+    let subscriptionName (name : string) = 
+        let exn = InvalidConfigurationException(sprintf "Invalid subscription name %A. See Azure Service Bus naming rules." name)
+        if name.Length > 50 then raise exn
+        if name |> Seq.forall (alphanumeric + set ['-'; '_';]).Contains |> not then raise exn
+        name

--- a/src/MBrace.Azure.Runtime/Common/Validation.fs
+++ b/src/MBrace.Azure.Runtime/Common/Validation.fs
@@ -27,24 +27,24 @@ module Validate =
         conn
 
     let tableName (name : string) =
-        let exn = InvalidConfigurationException(sprintf "Invalid table name %A. See Azure Table Storage naming rules." name)
+        let exn = InvalidConfigurationException(sprintf "Invalid table name %A. Name length should be between 3 and 63, containing alphanumeric characters." name)
         if name.Length < 3 || name.Length > 63 then raise exn
         if name |> Seq.forall alphanumeric.Contains |> not then raise exn
         name
 
     let containerName (name : string) = 
-        let exn = InvalidConfigurationException(sprintf "Invalid container name %A. See Azure Blob Storage naming rules." name)
+        let exn = InvalidConfigurationException(sprintf "Invalid container name %A. Name length should be between 3 and 63, containing lowercase characters or numbers." name)
         if name.Length < 3 || name.Length > 63 then raise exn
         if name |> Seq.forall (lower + number).Contains |> not then raise exn
         name
 
     let queueName (name : string) = 
-        let exn = InvalidConfigurationException(sprintf "Invalid queue name %A. See Azure Service Bus naming rules." name)
+        let exn = InvalidConfigurationException(sprintf "Invalid queue name %A. Name should contain only alphanumeric characters or '-','_','/' delimiters." name)
         if name |> Seq.forall (alphanumeric + set ['-'; '_'; '/']).Contains |> not then raise exn
         name
                 
     let subscriptionName (name : string) = 
-        let exn = InvalidConfigurationException(sprintf "Invalid subscription name %A. See Azure Service Bus naming rules." name)
+        let exn = InvalidConfigurationException(sprintf "Invalid subscription name %A. Name length should be less than 50, containing only alphanumeric characters or '-','_','/' delimiters." name)
         if name.Length > 50 then raise exn
-        if name |> Seq.forall (alphanumeric + set ['-'; '_';]).Contains |> not then raise exn
+        if name |> Seq.forall (alphanumeric + set ['-'; '_'; '/']).Contains |> not then raise exn
         name

--- a/src/MBrace.Azure.Runtime/Common/Version.fs
+++ b/src/MBrace.Azure.Runtime/Common/Version.fs
@@ -38,12 +38,12 @@ module internal Metadata =
     let toString (version : Version) (configurationId : ConfigurationId) =
         let metadata = { Version = version; ConfigurationId = configurationId }
         use sw = new StringWriter()
-        let json = Nessos.FsPickler.Json.JsonSerializer()
+        let json = Nessos.FsPickler.Json.JsonSerializer(omitHeader = true)
         json.Serialize(sw, metadata)
         sw.ToString()
 
     let fromString (metadata : string) =
-        let json = Nessos.FsPickler.Json.JsonSerializer()
+        let json = Nessos.FsPickler.Json.JsonSerializer(omitHeader = true)
         use sr = new StringReader(metadata)
         try
             json.Deserialize<Metadata>(sr)

--- a/src/MBrace.Azure.Runtime/MBrace.Azure.Runtime.fsproj
+++ b/src/MBrace.Azure.Runtime/MBrace.Azure.Runtime.fsproj
@@ -75,6 +75,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Common\Exceptions.fs" />
+    <Compile Include="Common\Validation.fs" />
     <Compile Include="Common\Config.fs" />
     <Compile Include="Common\Version.fs" />
     <Compile Include="Utilities\Utils.fs" />

--- a/src/MBrace.Azure.Runtime/Runtime/Init.fs
+++ b/src/MBrace.Azure.Runtime/Runtime/Init.fs
@@ -26,7 +26,7 @@ type internal Initializer =
                     let init () =
                         let domainName = System.AppDomain.CurrentDomain.FriendlyName
                         logger.LogInfof "Initializing Application Domain %A" domainName
-                        Config.Activate(config.WithAppendedId, false)
+                        Config.Activate(config, false)
                         logger.LogInfof "Configuration activated in AppDomain %A" domainName
                     let managerF = DomainLocal.Create(fun () -> 
                         RuntimeManager.CreateForAppDomain(config, workerId, logger, customResources) :> IRuntimeManager , workerId)

--- a/src/MBrace.Azure.Runtime/Runtime/JobManager/JobManager.fs
+++ b/src/MBrace.Azure.Runtime/Runtime/JobManager/JobManager.fs
@@ -49,6 +49,7 @@ type JobManager private (config : ConfigurationId, logger : ISystemLogger) =
         }
 
     member this.SetLocalWorkerId(id : IWorkerId) =
+        let _ = Validate.subscriptionName id.Id
         queue.LocalWorkerId <- id
         topic.LocalWorkerId <- id
         subscription <- Some(topic.GetSubscription(id))

--- a/src/MBrace.Azure.Runtime/Runtime/RuntimeManager.fs
+++ b/src/MBrace.Azure.Runtime/Runtime/RuntimeManager.fs
@@ -7,21 +7,9 @@ open System
 open MBrace.Store.Internals
 open MBrace.Azure.Store
 
-type RuntimeId = 
-    private { Id : string } with
-
-    interface IRuntimeId with
-        member x.Id : string = x.Id
-
-    override x.ToString() = x.Id
-
-    static member FromConfigurationId(config : ConfigurationId) =
-        { Id = Convert.ToBase64String(Config.Pickler.Pickle(config)) }
-
 [<AutoSerializable(false)>]
 type RuntimeManager private (config : ConfigurationId, uuid : string, logger : ISystemLogger, resources : ResourceRegistry) =
-    let runtimeId     = RuntimeId.FromConfigurationId(config)
-    do logger.LogInfof "RuntimeManager Id = %A" runtimeId
+    do logger.LogInfof "RuntimeManager Id = %A" (config :> IRuntimeId).Id
 
     do logger.LogInfo "Creating worker manager"
     let workerManager = WorkerManager.Create(config, logger)
@@ -90,7 +78,7 @@ type RuntimeManager private (config : ConfigurationId, uuid : string, logger : I
         jobManager.SetLocalWorkerId(workerId)
 
     interface IRuntimeManager with
-        member this.Id                       = runtimeId :> _
+        member this.Id                       = config :> _
         member this.Serializer               = Config.Pickler :> _
         member this.WorkerManager            = workerManager :> _
         member this.TaskManager              = taskManager :> _

--- a/src/MBrace.Azure.Runtime/Runtime/Service.fs
+++ b/src/MBrace.Azure.Runtime/Runtime/Service.fs
@@ -95,7 +95,7 @@ type Service (config : Configuration, serviceId : string) =
     member this.StartAsync() : Async<unit> =
         async {
             // TODO : Add Configuration check.
-            loggers.Add(StorageSystemLogger.Create(config.StorageConnectionString, config.WithAppendedId.RuntimeLogsTable, serviceId))
+            loggers.Add(StorageSystemLogger.Create(config.StorageConnectionString, config.GetConfigurationId().RuntimeLogsTable, serviceId))
             let logger = AttacheableLogger.FromLoggers(loggers)
             try
                 let sw = Stopwatch.StartNew()

--- a/tests/MBrace.Azure.Runtime.Tests/FlowTests.fs
+++ b/tests/MBrace.Azure.Runtime.Tests/FlowTests.fs
@@ -13,10 +13,7 @@ open NUnit.Framework
 type ``Azure Flow Tests`` (sbus, storage) as self =
     inherit ``CloudFlow tests`` ()
 
-    let config = 
-        { Configuration.Default with
-            StorageConnectionString = storage
-            ServiceBusConnectionString = sbus }
+    let config = new Configuration(storage, sbus)
 
     let session = new RuntimeSession(config)
 

--- a/tests/MBrace.Azure.Runtime.Tests/Tests.fs
+++ b/tests/MBrace.Azure.Runtime.Tests/Tests.fs
@@ -15,10 +15,7 @@ open MBrace.Azure.Runtime
 type ``Azure Runtime Tests`` (sbus, storage) as self =
     inherit ``Parallelism Tests`` (parallelismFactor = 4, delayFactor = 10000)
     
-    let config = 
-        { Configuration.Default with
-            StorageConnectionString = storage
-            ServiceBusConnectionString = sbus }
+    let config = new Configuration(storage, sbus)
 
     let session = new RuntimeSession(config)
 

--- a/tests/MBrace.Azure.Runtime.Tests/Utils.fs
+++ b/tests/MBrace.Azure.Runtime.Tests/Utils.fs
@@ -66,7 +66,7 @@ type RuntimeSession(config : MBrace.Azure.Configuration) =
         state <- Some (runtime, logTest)
 
     member __.Stop () =
-        state |> Option.iter (fun (r,l) -> (r.KillLocalWorker() ; r.Reset(true, true, true, true, true)))
+        state |> Option.iter (fun (r,l) -> (r.KillLocalWorker() ; r.Reset(true, true, true, true, true, false)))
         state <- None
 
     member __.Runtime =

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -13,7 +13,7 @@ open System
 open MBrace.Store
 
 let config = 
-    let selectEnv name = Environment.GetEnvironmentVariable(name,EnvironmentVariableTarget.Machine)
+    let selectEnv name = Environment.GetEnvironmentVariable(name,EnvironmentVariableTarget.User)
     new Configuration(selectEnv "azurestorageconn", selectEnv "azureservicebusconn")
 
 MBraceAzure.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"

--- a/tests/MBrace.Azure.Runtime.Tests/test.fsx
+++ b/tests/MBrace.Azure.Runtime.Tests/test.fsx
@@ -11,29 +11,15 @@ open MBrace.Core
 open MBrace.Azure
 open System
 open MBrace.Store
-open System.IO
-
-MBraceAzure.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-
-let selectEnv name =
-    (Environment.GetEnvironmentVariable(name,EnvironmentVariableTarget.User),
-      Environment.GetEnvironmentVariable(name,EnvironmentVariableTarget.Machine),
-        Environment.GetEnvironmentVariable(name,EnvironmentVariableTarget.Process))
-    |> function 
-       | s, _, _ when not <| String.IsNullOrEmpty(s) -> s
-       | _, s, _ when not <| String.IsNullOrEmpty(s) -> s
-       | _, _, s when not <| String.IsNullOrEmpty(s) -> s
-       | _ -> failwith "Variable not found"
 
 let config = 
-    { Configuration.Default with
-        StorageConnectionString = selectEnv "azurestorageconn"
-        ServiceBusConnectionString = selectEnv "azureservicebusconn" }
+    let selectEnv name = Environment.GetEnvironmentVariable(name,EnvironmentVariableTarget.Machine)
+    new Configuration(selectEnv "azurestorageconn", selectEnv "azureservicebusconn")
 
-//MBraceAzure.Reset(config)
+MBraceAzure.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
 let runtime = MBraceAzure.InitLocal(config, 4)
-let runtime = MBraceAzure.GetHandle(config)
-runtime.EnableClientConsoleLogging <- false
+//let runtime = MBraceAzure.GetHandle(config)
+runtime.EnableClientConsoleLogger <- true
 runtime.Workers
 
 runtime.ShowWorkerInfo()


### PR DESCRIPTION
This PR contains a refactoring on the `Configuration` type.
* `Configuration` is no longer an F# record, making it easier to set up in C# code.
* `Configuration` has two extra properties `UseVersionPostfix` and `UseIdPostfix`. Both default to true and append the version and configuration id in all containers/tables/etc created by the runtime (same as before, but now it can be turned off).
* `Configuration` now isolates runtimes using only the major and minor version numbers (e.g. versions X.Y.\*.\* will use the same containers), instead of using the full version string.
* Added a `MBraceAzure.GetHandle` overload that accepts two connection strings instead of a `Configuration`.
* Added validation for the configuration inputs and worker id.
