### PR TITLE
Client and Service API renaming

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 ### 0.10.0-alpha
 * Migrate to MBrace.Core 0.10 APIs
 * Fix MBraceAzure.ClearAllCloudTasks bug.
+* Client and Service API changed to match MBrace.Core.
+* Added extra options when spawning local workers.
 
 ### 0.7.0-alpha
 * Migrate to MBrace.Runtime.Core 0.9.14 APIs

--- a/src/MBrace.Azure.StandaloneWorker/main.fs
+++ b/src/MBrace.Azure.StandaloneWorker/main.fs
@@ -21,7 +21,7 @@ let main (args : string []) =
         svc.MaxConcurrentJobs <- cfg.MaxTasks
         Console.Title <- sprintf "%s(%d) : %s"  ps.ProcessName ps.Id svc.Id
 
-        svc.AttachLogger(ConsoleLogger(showDate = true, useColors = true))
+        let _ = svc.AttachLogger(ConsoleLogger(showDate = true, useColors = true))
         svc.Run()
         0
     with e ->

--- a/src/MBrace.Azure.StandaloneWorker/main.fs
+++ b/src/MBrace.Azure.StandaloneWorker/main.fs
@@ -18,9 +18,9 @@ let main (args : string []) =
             | None -> sprintf "%s-%05d" <| System.Net.Dns.GetHostName() <| ps.Id
             | Some n -> n
         let svc = new Service(config, workerId)
-        svc.MaxConcurrentJobs <- cfg.MaxTasks
+        svc.MaxConcurrentJobs <- cfg.MaxJobs
         Console.Title <- sprintf "%s(%d) : %s"  ps.ProcessName ps.Id svc.Id
-
+        cfg.LogLevel |> Option.iter (fun l -> svc.LogLevel <- l)
         let _ = svc.AttachLogger(ConsoleLogger(showDate = true, useColors = true))
         svc.Run()
         0

--- a/src/MBrace.Azure/Client.fs
+++ b/src/MBrace.Azure/Client.fs
@@ -14,7 +14,10 @@ open MBrace.Azure.Runtime
 open MBrace.Azure.Runtime.Arguments
 open MBrace.Runtime
 
+/// A system logger that writes entries to stdout
 type ConsoleLogger = MBrace.Runtime.ConsoleLogger
+/// Log level used by the MBrace runtime implementation
+type LogLevel = MBrace.Runtime.LogLevel
 
 /// <summary>
 /// Windows Azure Runtime client.

--- a/src/MBrace.Azure/Client.fs
+++ b/src/MBrace.Azure/Client.fs
@@ -64,7 +64,7 @@ type MBraceCluster private (manager : RuntimeManager, defaultLogger : SystemLogg
     /// <summary>
     /// Kill all local worker processes.
     /// </summary>
-    member this.KillLocalWorker() =
+    member this.KillAllLocalWorkers() =
         let workers = this.Workers
         let exists id hostname =
             if Net.Dns.GetHostName() = hostname then

--- a/src/MBrace.Azure/Primitives/Logging.fs
+++ b/src/MBrace.Azure/Primitives/Logging.fs
@@ -59,8 +59,8 @@ type private StorageLoggerMessage =
 
 [<Sealed; DataContract>]
 type SystemLogger private (storageConn : string, table : string, loggerId : string) =
-    let [<DataMember(Name = "storageConn")>] storageConn = storageConn
-    let [<DataMember(Name = "table")>] table = table
+    let [<DataMember(Name = "storageConn")>] storageConn = Validate.storageConn storageConn
+    let [<DataMember(Name = "table")>] table = Validate.tableName table
     let [<DataMember(Name = "loggerId")>] loggerId = loggerId
 
     let [<IgnoreDataMember>] mutable agent = Unchecked.defaultof<MailboxProcessor<StorageLoggerMessage>>

--- a/src/MBrace.Azure/Primitives/Logging.fs
+++ b/src/MBrace.Azure/Primitives/Logging.fs
@@ -257,14 +257,6 @@ type CustomLogger (f : Action<string>) =
 
 [<AutoOpen>]
 module LoggerExtensions =
-    
-    type AttacheableLogger with
-        static member FromLoggers(loggers : ISystemLogger seq) = 
-            let logger = AttacheableLogger.Create(makeAsynchronous = false)
-            for l in loggers do
-                ignore(logger.AttachLogger(l))
-            logger
-
     type ISystemLogger with
         member this.LogInfof fmt = Printf.ksprintf (fun s -> this.LogInfo s) fmt
         member this.LogErrorf fmt = Printf.ksprintf (fun s -> this.LogError s) fmt

--- a/src/MBrace.Azure/Runtime/Init.fs
+++ b/src/MBrace.Azure/Runtime/Init.fs
@@ -9,7 +9,7 @@ open MBrace.Core
 type internal Initializer =
     static member Init(config : Configuration,
                         workerId : string, 
-                        logger : ISystemLogger, 
+                        logger : AttacheableLogger, 
                         useAppDomainIsolation : bool,
                         maxConcurrentJobs : int, 
                         customResources : ResourceRegistry) =

--- a/src/MBrace.Azure/Runtime/RuntimeManager.fs
+++ b/src/MBrace.Azure/Runtime/RuntimeManager.fs
@@ -9,39 +9,37 @@ open MBrace.Azure
 open MBrace.Azure.Store
 
 [<AutoSerializable(false)>]
-type RuntimeManager private (config : ConfigurationId, uuid : string, customLogger : ISystemLogger, resources : ResourceRegistry) =
-    let logger = AttacheableLogger.Create(makeAsynchronous = true)
-    do ignore <| logger.AttachLogger customLogger
-    do logger.LogInfof "RuntimeManager Id = %A" (config :> IRuntimeId).Id
+type RuntimeManager private (config : ConfigurationId, uuid : string, systemLogger : AttacheableLogger, resources : ResourceRegistry) =
+    do systemLogger.LogInfof "RuntimeManager Id = %A" (config :> IRuntimeId).Id
 
-    do logger.LogInfo "Creating worker manager"
-    let workerManager = WorkerManager.Create(config, logger)
-    do logger.LogInfo "Creating job manager"
-    let jobManager    = JobManager.Create(config, logger)
-    do logger.LogInfo "Creating task manager"
-    let taskManager   = TaskManager.Create(config, logger)
-    do logger.LogInfo "Creating assembly manager"
+    do systemLogger.LogInfo "Creating worker manager"
+    let workerManager = WorkerManager.Create(config, systemLogger)
+    do systemLogger.LogInfo "Creating job manager"
+    let jobManager    = JobManager.Create(config, systemLogger)
+    do systemLogger.LogInfo "Creating task manager"
+    let taskManager   = TaskManager.Create(config, systemLogger)
+    do systemLogger.LogInfo "Creating assembly manager"
     let store = resources.Resolve<ICloudFileStore>()
 
     let assemblyManager =
         let serializer = resources.Resolve<ISerializer>()
         let config = StoreAssemblyManagerConfiguration.Create(store, serializer, container = config.VagabondContainer)
-        StoreAssemblyManager.Create(config, localLogger = logger)
+        StoreAssemblyManager.Create(config, localLogger = systemLogger)
 
     do
         let cloudValueProvider = resources.Resolve<ICloudValueProvider>()
         let csc = ClosureSiftConfiguration.Create(cloudValueProvider, siftThreshold = 5L * 1024L * 1024L)
-        let manager = ClosureSiftManager.Create(csc, localLogger = logger)
+        let manager = ClosureSiftManager.Create(csc, localLogger = systemLogger)
         ConfigurationRegistry.Register<ClosureSiftManager>(config, manager)
 
-    do logger.LogInfo "Creating CloudLog manager"
+    do systemLogger.LogInfo "Creating CloudLog manager"
     let cloudLogManager = CloudLogManager.Create(config)
 
     let cancellationEntryFactory = CancellationTokenFactory.Create(config)
     let int32CounterFactory = Int32CounterFactory.Create(config)
     let resultAggregatorFactory = ResultAggregatorFactory.Create(config)
 
-    do logger.LogInfo "RuntimeManager initialization complete"
+    do systemLogger.LogInfo "RuntimeManager initialization complete"
 
     member this.RuntimeManagerId = uuid
     member this.Resources = resources
@@ -53,44 +51,44 @@ type RuntimeManager private (config : ConfigurationId, uuid : string, customLogg
                 let! workers = (workerManager :> IWorkerManager).GetAvailableWorkers()
                 if  workers.Length > 0 then
                     let exc = RuntimeException(sprintf "Found %d active workers. Shutdown workers first or 'force' reset." workers.Length)
-                    logger.LogError exc.Message
+                    systemLogger.LogError exc.Message
                     return! Async.Raise exc
              
             
             if deleteQueues then 
-                logger.LogWarningf "Deleting Queues %A, %A." config.RuntimeQueue config.RuntimeTable
+                systemLogger.LogWarningf "Deleting Queues %A, %A." config.RuntimeQueue config.RuntimeTable
                 do! Config.DeleteRuntimeQueues(config)
             
             if deleteState then 
-                logger.LogWarningf "Deleting Container %A and Table %A." config.RuntimeContainer config.RuntimeTable
+                systemLogger.LogWarningf "Deleting Container %A and Table %A." config.RuntimeContainer config.RuntimeTable
                 do! Config.DeleteRuntimeState(config)
             
             if deleteLogs then 
-                logger.LogWarningf "Deleting Logs Table %A." config.RuntimeLogsTable
+                systemLogger.LogWarningf "Deleting Logs Table %A." config.RuntimeLogsTable
                 do! Config.DeleteRuntimeLogs(config)
 
             if deleteUserData then 
-                logger.LogWarningf "Deleting UserData Container %A and Table %A." config.UserDataContainer config.UserDataTable
+                systemLogger.LogWarningf "Deleting UserData Container %A and Table %A." config.UserDataContainer config.UserDataTable
                 do! Config.DeleteUserData(config)
 
             if deleteVagabondData then
-                logger.LogWarningf "Deleting Vagadbond Container %A." config.VagabondContainer
+                systemLogger.LogWarningf "Deleting Vagadbond Container %A." config.VagabondContainer
                 do! Config.DeleteVagabondData(config)
     
             if reactivate then        
-                logger.LogInfo "Reactivating configuration."
+                systemLogger.LogInfo "Reactivating configuration."
                 let rec loop retryCount = async {
-                    logger.LogInfof "RetryCount %d." retryCount
+                    systemLogger.LogInfof "RetryCount %d." retryCount
                     let! step2 = Async.Catch <| Config.ReactivateAsync(config)
                     match step2 with
                     | Choice1Of2 _ -> ()
                     | Choice2Of2 ex ->
-                        logger.LogWarningf "Failed with %A\nWaiting." ex
+                        systemLogger.LogWarningf "Failed with %A\nWaiting." ex
                         do! Async.Sleep 10000
                         return! loop (retryCount + 1)
                 }
                 do! loop 0
-            logger.LogInfo "Reset : done."
+            systemLogger.LogInfo "Reset : done."
             return ()
         }
 
@@ -104,16 +102,16 @@ type RuntimeManager private (config : ConfigurationId, uuid : string, customLogg
         member this.TaskManager              = taskManager :> _
         member this.JobQueue                 = jobManager :> _
         member this.AssemblyManager          = assemblyManager :> _
-        member this.SystemLogger             = logger :> _
-        member this.AttachSystemLogger l     = logger.AttachLogger l
+        member this.SystemLogger             = systemLogger :> _
+        member this.AttachSystemLogger l     = systemLogger.AttachLogger l
         member this.CancellationEntryFactory = cancellationEntryFactory
         member this.CounterFactory           = int32CounterFactory
         member this.ResetClusterState()      = this.ResetCluster(true, true, true, false, false, false, true)
         member this.ResourceRegistry         = resources
         member this.ResultAggregatorFactory  = resultAggregatorFactory
         member this.CloudLogManager          = cloudLogManager :> _
-        member this.LogLevel                 = logger.LogLevel
-        member this.LogLevel with set l      = logger.LogLevel <- l
+        member this.LogLevel                 = systemLogger.LogLevel
+        member this.LogLevel with set l      = systemLogger.LogLevel <- l
 
 
     static member private GetDefaultResources(config : Configuration, customResources : ResourceRegistry) =
@@ -143,30 +141,32 @@ type RuntimeManager private (config : ConfigurationId, uuid : string, customLogg
             yield! customResources
         }
 
-    static member CreateForWorker(config : Configuration, workerId : IWorkerId, customLogger : ISystemLogger, customResources) =
-        customLogger.LogInfof "Activating configuration with Id %A" config.Id
+    static member CreateForWorker(config : Configuration, workerId : IWorkerId, logger : AttacheableLogger, customResources) =
+        logger.LogInfof "Activating configuration with Id %A" config.Id
         Config.Activate(config, true)
-        customLogger.LogInfof "Creating resources"
+        logger.LogInfof "Creating resources"
         let resources = RuntimeManager.GetDefaultResources(config, customResources)
-        customLogger.LogInfof "Creating RuntimeManager for Worker %A" workerId
-        let runtime = new RuntimeManager(config.GetConfigurationId(), workerId.Id, customLogger, resources)
+        logger.LogInfof "Creating RuntimeManager for Worker %A" workerId
+        let runtime = new RuntimeManager(config.GetConfigurationId(), workerId.Id, logger, resources)
         runtime.SetLocalWorkerId(workerId)
         runtime
 
-    static member CreateForAppDomain(config : Configuration, workerId : IWorkerId, customLogger : ISystemLogger, customResources) =
-        customLogger.LogInfof "Activating configuration with Id %A" config.Id
+    static member CreateForAppDomain(config : Configuration, workerId : IWorkerId, logger : MarshaledLogger, customResources) =
+        logger.LogInfof "Activating configuration with Id %A" config.Id
         Config.Activate(config, false)
-        customLogger.LogInfof "Creating resources"
+        logger.LogInfof "Creating resources"
         let resources = RuntimeManager.GetDefaultResources(config, customResources)
-        customLogger.LogInfof "Creating RuntimeManager for AppDomain %A" AppDomain.CurrentDomain.FriendlyName
-        let runtime = new RuntimeManager(config.GetConfigurationId(), workerId.Id, customLogger, resources)
+        logger.LogInfof "Creating RuntimeManager for AppDomain %A" AppDomain.CurrentDomain.FriendlyName
+        let logger = AttacheableLogger.Create(makeAsynchronous = true)
+        let _ = logger.AttachLogger(logger)
+        let runtime = new RuntimeManager(config.GetConfigurationId(), workerId.Id, logger, resources)
         runtime
 
-    static member CreateForClient(config : Configuration, clientId : string, customLogger : ISystemLogger, customResources) =
-        customLogger.LogInfof "Activating configuration with Id %A" config.Id
+    static member CreateForClient(config : Configuration, clientId : string, logger : AttacheableLogger, customResources) =
+        logger.LogInfof "Activating configuration with Id %A" config.Id
         Config.Activate(config, true)
-        customLogger.LogInfof "Creating resources"        
+        logger.LogInfof "Creating resources"        
         let resources = RuntimeManager.GetDefaultResources(config, customResources)
-        customLogger.LogInfof "Creating RuntimeManager for Client %A" clientId
-        let runtime = new RuntimeManager(config.GetConfigurationId(), clientId, customLogger, resources)
+        logger.LogInfof "Creating RuntimeManager for Client %A" clientId
+        let runtime = new RuntimeManager(config.GetConfigurationId(), clientId, logger, resources)
         runtime

--- a/src/MBrace.Azure/Utilities/Argument.fs
+++ b/src/MBrace.Azure/Utilities/Argument.fs
@@ -4,13 +4,14 @@ open MBrace.Azure
 open MBrace.Azure.Runtime
 open MBrace.Runtime
 
-// TODO replace with UnionArgParser
+// TODO replace with Argu
 /// BASE64 serialized argument parsing schema
     
 type Config = { 
     Configuration : Configuration
-    MaxTasks : int
+    MaxJobs : int
     Name : string option
+    LogLevel : LogLevel option
 }
 with
     static member ToBase64Pickle (config : Config) =

--- a/tests/MBrace.Azure.Tests/CloudTests.fs
+++ b/tests/MBrace.Azure.Tests/CloudTests.fs
@@ -99,7 +99,7 @@ type ``Standalone - Storage Emulator`` () =
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
         MBraceCluster.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        MBraceCluster.SpawnLocal(base.Configuration, 4, 32) 
+        MBraceCluster.SpawnOnCurrentMachine(base.Configuration, 4, 32) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]
@@ -115,7 +115,7 @@ type ``Standalone`` () =
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
         MBraceCluster.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        MBraceCluster.SpawnLocal(base.Configuration, 4, 32) 
+        MBraceCluster.SpawnOnCurrentMachine(base.Configuration, 4, 32) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]

--- a/tests/MBrace.Azure.Tests/CloudTests.fs
+++ b/tests/MBrace.Azure.Tests/CloudTests.fs
@@ -98,8 +98,8 @@ type ``Standalone - Storage Emulator`` () =
 
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
-        MBraceAzure.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        MBraceAzure.SpawnLocal(base.Configuration, 4, 32) 
+        MBraceCluster.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
+        MBraceCluster.SpawnLocal(base.Configuration, 4, 32) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]
@@ -114,8 +114,8 @@ type ``Standalone`` () =
     
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
-        MBraceAzure.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        MBraceAzure.SpawnLocal(base.Configuration, 4, 32) 
+        MBraceCluster.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
+        MBraceCluster.SpawnLocal(base.Configuration, 4, 32) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]

--- a/tests/MBrace.Azure.Tests/FlowTests.fs
+++ b/tests/MBrace.Azure.Tests/FlowTests.fs
@@ -53,8 +53,8 @@ type ``CloudFlow Standalone - Storage Emulator`` () =
 
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
-        MBraceAzure.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        MBraceAzure.SpawnLocal(base.Configuration, 4, 16) 
+        MBraceCluster.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
+        MBraceCluster.SpawnLocal(base.Configuration, 4, 16) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]
@@ -69,8 +69,8 @@ type ``CloudFlow Standalone`` () =
     
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
-        MBraceAzure.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        MBraceAzure.SpawnLocal(base.Configuration, 4, 16) 
+        MBraceCluster.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
+        MBraceCluster.SpawnLocal(base.Configuration, 4, 16) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]

--- a/tests/MBrace.Azure.Tests/FlowTests.fs
+++ b/tests/MBrace.Azure.Tests/FlowTests.fs
@@ -54,7 +54,7 @@ type ``CloudFlow Standalone - Storage Emulator`` () =
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
         MBraceCluster.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        MBraceCluster.SpawnLocal(base.Configuration, 4, 16) 
+        MBraceCluster.SpawnOnCurrentMachine(base.Configuration, 4, 16) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]
@@ -70,7 +70,7 @@ type ``CloudFlow Standalone`` () =
     [<TestFixtureSetUpAttribute>]
     override __.Init() =
         MBraceCluster.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-        MBraceCluster.SpawnLocal(base.Configuration, 4, 16) 
+        MBraceCluster.SpawnOnCurrentMachine(base.Configuration, 4, 16) 
         base.Init()
         
     [<TestFixtureTearDownAttribute>]

--- a/tests/MBrace.Azure.Tests/Utils.fs
+++ b/tests/MBrace.Azure.Tests/Utils.fs
@@ -56,7 +56,7 @@ type RuntimeSession(config : MBrace.Azure.Configuration) =
         state <- Some runtime
 
     member __.Stop () =
-        state |> Option.iter (fun r -> (r.KillLocalWorker() ; r.Reset(true, true, true, true, true, true, false)))
+        state |> Option.iter (fun r -> (r.KillAllLocalWorkers() ; r.Reset(true, true, true, true, true, true, false)))
         state <- None
 
     member __.Runtime =

--- a/tests/MBrace.Azure.Tests/Utils.fs
+++ b/tests/MBrace.Azure.Tests/Utils.fs
@@ -52,8 +52,7 @@ type RuntimeSession(config : MBrace.Azure.Configuration) =
     let mutable state = None
 
     member __.Start () = 
-        let runtime = MBraceAzure.GetHandle(config)
-        runtime.EnableClientConsoleLogger <- true
+        let runtime = MBraceAzure.GetHandle(config, logger = ConsoleLogger(), logLevel = LogLevel.Debug)
         state <- Some runtime
 
     member __.Stop () =

--- a/tests/MBrace.Azure.Tests/Utils.fs
+++ b/tests/MBrace.Azure.Tests/Utils.fs
@@ -52,7 +52,7 @@ type RuntimeSession(config : MBrace.Azure.Configuration) =
     let mutable state = None
 
     member __.Start () = 
-        let runtime = MBraceAzure.GetHandle(config, logger = ConsoleLogger(), logLevel = LogLevel.Debug)
+        let runtime = MBraceCluster.GetHandle(config, logger = ConsoleLogger(), logLevel = LogLevel.Debug)
         state <- Some runtime
 
     member __.Stop () =

--- a/tests/MBrace.Azure.Tests/test.fsx
+++ b/tests/MBrace.Azure.Tests/test.fsx
@@ -14,12 +14,12 @@ let config =
     let selectEnv name = Environment.GetEnvironmentVariable(name,EnvironmentVariableTarget.User)
     new Configuration(selectEnv "azurestorageconn", selectEnv "azureservicebusconn")
 
-MBraceAzure.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
-let runtime = MBraceAzure.InitLocal(config, 4)
-//let runtime = MBraceAzure.GetHandle(config)
-runtime.EnableClientConsoleLogger <- true
+MBraceCluster.LocalWorkerExecutable <- __SOURCE_DIRECTORY__ + "/../../bin/mbrace.azureworker.exe"
+let runtime = MBraceCluster.InitOnCurrentMachine(config, 8, 32, logger = ConsoleLogger(true), logLevel = LogLevel.Debug)
+
 runtime.Workers
 
+runtime.KillAllLocalWorkers()
 runtime.Reset(true,true,true,true,true,true,false)
 
 let task = runtime.CreateCloudTask(cloud { return! Cloud.Log "Hello" }, faultPolicy = FaultPolicy.NoRetry)
@@ -30,8 +30,6 @@ task.ShowLogs()
 let d = task.Logs.Subscribe(fun l -> printfn "%s" l.Message)
 d.Dispose()
 
-
-runtime.KillLocalWorker()
 
 
 let task =


### PR DESCRIPTION
This PR contains a few renames and minor additions in order to increase naming compatibility with MBrace.Core.

* `MBraceAzure` (client) renamed to `MBraceCluster`.
* `ClientId` renamed to `UUID`.
* `KillLocalWorker()` renamed to `KilledAllLocalWorkers`.
* Added `LogLevel` alias in `MBrace.Azure` namespace.
* `InitLocal` renamed to `InitOnCurrentMachine` (same with `SpawnLocal`).
* Added logger and loglevel optional parameters to InitLocal/etc.
* Removed `EnableConsoleLogger` from client.
* Added `AttachLogger`, `LogLevel` APIs in `Service`.