### PR TITLE
Fix capitalization in package template

### DIFF
--- a/src/MBrace.Azure/paket.template
+++ b/src/MBrace.Azure/paket.template
@@ -9,7 +9,7 @@ copyright
 summary
     An MBrace cluster implementation on top of Azure PaaS.
 	Bundles a standalone executable for setup of local worker instances.
-licenseurl https://github.com/mbraceproject/MBrace.Azure/blob/master/License.md
+licenseurl https://github.com/mbraceproject/MBrace.Azure/blob/master/LICENSE.md
 projecturl http://www.m-brace.net/
 iconurl https://avatars2.githubusercontent.com/u/9674757
 tags


### PR DESCRIPTION
This is causing a failure in the download of the 0.12-2 MBrace.Azure package

    Could not download license for MBrace.Azure 0.12.3-beta from https://github.com/mbraceproject/MBrace.Azure/blob/master/License.md.
    EXEC : The remote server returned an error : (404) Not Found. [C:\GitHub\dsyme\
MBrace.StarterKit\HandsOnTutorial\HandsOnTutorial.fsproj]