### PR TITLE
provisioning first cut

### DIFF
--- a/nuget/MBrace.Azure.fsx
+++ b/nuget/MBrace.Azure.fsx
@@ -17,6 +17,17 @@
 #r @"tools\MBrace.Runtime.dll"
 #r @"tools\MBrace.Azure.dll"
 
+// Needed for managment operations like provisioning:
+#r @"tools\Hyak.Common.dll"
+#r @"tools\Microsoft.Azure.Common.dll"
+#r @"tools\Microsoft.Threading.Tasks.dll"
+#r @"tools\Microsoft.Azure.Common.NetFramework.dll"
+#r @"tools\Microsoft.WindowsAzure.Management.dll"
+#r @"tools\Microsoft.WindowsAzure.Management.Compute.dll"
+#r @"tools\Microsoft.WindowsAzure.Management.Storage.dll"
+#r @"tools\Microsoft.WindowsAzure.Management.ServiceBus.dll"
+#r "System.Runtime"
+#r "System.Threading.Tasks"
 open System.IO
 open MBrace.Azure
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -16,3 +16,6 @@ nuget MathNet.Numerics ~> 3.7.0
 nuget MathNet.Numerics.FSharp
 nuget MathNet.Numerics.MKL.Win-x64 ~> 1.8.0
 nuget Argu ~> 1.0
+nuget Microsoft.WindowsAzure.Management.Libraries
+nuget Microsoft.WindowsAzure.Management.ServiceBus
+nuget Microsoft.Bcl.Async

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -19,3 +19,4 @@ nuget Argu ~> 1.0
 nuget Microsoft.WindowsAzure.Management.Libraries
 nuget Microsoft.WindowsAzure.Management.ServiceBus
 nuget Microsoft.Bcl.Async
+github fsharp/FAKE modules/Octokit/Octokit.fsx

--- a/paket.lock
+++ b/paket.lock
@@ -12,6 +12,12 @@ NUGET
     FsPickler.Json (1.5.2)
       FsPickler (1.5.2)
       Newtonsoft.Json (>= 6.0.5)
+    Hyak.Common (1.0.3)
+      Microsoft.Bcl (>= 1.1.9) - framework: portable-net403+win+wpa81
+      Microsoft.Bcl.Async (>= 1.0.168) - framework: portable-net403+win+wpa81
+      Microsoft.Bcl.Build (>= 1.0.14) - framework: portable-net403+win+wpa81
+      Microsoft.Net.Http (>= 2.2.22) - framework: portable-net403+win+wpa81
+      Newtonsoft.Json (>= 6.0.4) - framework: portable-net403+win+wpa81
     MathNet.Numerics (3.7.1)
       TaskParallelLibrary (>= 1.0.2856) - framework: net35
     MathNet.Numerics.FSharp (3.7.1)
@@ -33,13 +39,69 @@ NUGET
       MBrace.Core (0.16.0-beta)
       MBrace.Flow (0.16.0-beta)
       NUnit (>= 2.6.3)
+    Microsoft.Azure.Common (2.1.0)
+      Hyak.Common (>= 1.0.2)
+      Microsoft.Azure.Common.Dependencies (>= 1.0.0)
+    Microsoft.Azure.Common.Dependencies (1.0.0)
+      Microsoft.Bcl (>= 1.1.9) - framework: portable-net45+wp80+wpa81+win, >= net40
+      Microsoft.Bcl.Async (>= 1.0.168) - framework: portable-net45+wp80+wpa81+win, >= net40
+      Microsoft.Bcl.Build (>= 1.0.14) - framework: portable-net45+wp80+wpa81+win, >= net40
+      Microsoft.Net.Http (>= 2.2.22) - framework: portable-net45+wp80+wpa81+win, >= net40
+      Newtonsoft.Json (>= 6.0.4) - framework: portable-net45+wp80+wpa81+win, >= net40
+    Microsoft.Bcl (1.1.10)
+      Microsoft.Bcl.Build (>= 1.0.14)
+    Microsoft.Bcl.Async (1.0.168)
+      Microsoft.Bcl (>= 1.1.8)
+    Microsoft.Bcl.Build (1.0.21) - import_targets: false
     Microsoft.Data.Edm (5.6.4) - framework: winv4.5, wpv8.1, wpv8.0, >= net40
     Microsoft.Data.OData (5.6.4) - framework: winv4.5, wpv8.1, wpv8.0, >= net40
       Microsoft.Data.Edm (5.6.4)
       System.Spatial (5.6.4)
     Microsoft.Data.Services.Client (5.6.4) - framework: >= net40
       Microsoft.Data.OData (5.6.4)
-    Microsoft.WindowsAzure.ConfigurationManager (3.1.0) - framework: >= net40
+    Microsoft.Net.Http (2.2.29) - framework: portable-net45+wp80+wpa81+win, >= net40
+      Microsoft.Bcl (>= 1.1.10)
+      Microsoft.Bcl.Build (>= 1.0.14)
+    Microsoft.WindowsAzure.Common (1.4.1)
+      Microsoft.WindowsAzure.Common.Dependencies (>= 1.1.1)
+    Microsoft.WindowsAzure.Common.Dependencies (1.1.1)
+      Microsoft.Bcl (>= 1.1.9) - framework: portable-net45+wp80+wpa81+win, >= net40
+      Microsoft.Bcl.Async (>= 1.0.168) - framework: portable-net45+wp80+wpa81+win, >= net40
+      Microsoft.Bcl.Build (>= 1.0.14) - framework: portable-net45+wp80+wpa81+win, >= net40
+      Microsoft.Net.Http (>= 2.2.22) - framework: portable-net45+wp80+wpa81+win, >= net40
+      Newtonsoft.Json (>= 6.0.4) - framework: portable-net45+wp80+wpa81+win, >= net40
+    Microsoft.WindowsAzure.ConfigurationManager (3.1.0)
+    Microsoft.WindowsAzure.Management (4.1.1)
+      Microsoft.Azure.Common (>= 2.0.4 < 3.0)
+    Microsoft.WindowsAzure.Management.Compute (12.3.1)
+      Microsoft.Azure.Common (>= 2.0.4 < 3.0)
+    Microsoft.WindowsAzure.Management.Libraries (2.0.0)
+      Microsoft.WindowsAzure.Common (>= 1.3.0 < 2.0)
+      Microsoft.WindowsAzure.Management (>= 2.0.0)
+      Microsoft.WindowsAzure.Management.Compute (>= 5.0.0)
+      Microsoft.WindowsAzure.Management.MediaServices (>= 2.0.0)
+      Microsoft.WindowsAzure.Management.Monitoring (>= 1.0.0)
+      Microsoft.WindowsAzure.Management.Network (>= 3.0.0)
+      Microsoft.WindowsAzure.Management.Scheduler (>= 3.0.0)
+      Microsoft.WindowsAzure.Management.Sql (>= 3.0.0)
+      Microsoft.WindowsAzure.Management.Storage (>= 3.0.0)
+      Microsoft.WindowsAzure.Management.WebSites (>= 3.0.0)
+    Microsoft.WindowsAzure.Management.MediaServices (4.1.0)
+      Microsoft.Azure.Common (>= 2.0.1 < 3.0)
+    Microsoft.WindowsAzure.Management.Monitoring (4.1.0)
+      Microsoft.Azure.Common (>= 2.0.1 < 3.0)
+    Microsoft.WindowsAzure.Management.Network (7.0.3)
+      Microsoft.Azure.Common (>= 2.1.0 < 3.0)
+    Microsoft.WindowsAzure.Management.Scheduler (6.2.0)
+      Microsoft.Azure.Common (>= 2.0.4 < 3.0)
+    Microsoft.WindowsAzure.Management.ServiceBus (0.17.1-preview)
+      Microsoft.Azure.Common (>= 2.0.1 < 3.0)
+    Microsoft.WindowsAzure.Management.Sql (5.2.0)
+      Microsoft.Azure.Common (>= 2.0.4 < 3.0)
+    Microsoft.WindowsAzure.Management.Storage (5.1.1)
+      Microsoft.Azure.Common (>= 2.0.4 < 3.0)
+    Microsoft.WindowsAzure.Management.WebSites (4.0.0)
+      Microsoft.WindowsAzure.Common (>= 1.3.0 < 2.0)
     Mono.Cecil (0.9.6.1)
     Newtonsoft.Json (7.0.1)
     NuGet.CommandLine (2.8.6)

--- a/paket.lock
+++ b/paket.lock
@@ -59,7 +59,7 @@ NUGET
       System.Spatial (5.6.4)
     Microsoft.Data.Services.Client (5.6.4) - framework: >= net40
       Microsoft.Data.OData (5.6.4)
-    Microsoft.Net.Http (2.2.29) - framework: portable-net45+wp80+wpa81+win, >= net40
+    Microsoft.Net.Http (2.2.29)
       Microsoft.Bcl (>= 1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
     Microsoft.WindowsAzure.Common (1.4.1)
@@ -70,7 +70,7 @@ NUGET
       Microsoft.Bcl.Build (>= 1.0.14) - framework: portable-net45+wp80+wpa81+win, >= net40
       Microsoft.Net.Http (>= 2.2.22) - framework: portable-net45+wp80+wpa81+win, >= net40
       Newtonsoft.Json (>= 6.0.4) - framework: portable-net45+wp80+wpa81+win, >= net40
-    Microsoft.WindowsAzure.ConfigurationManager (3.1.0)
+    Microsoft.WindowsAzure.ConfigurationManager (3.1.0) - framework: >= net40
     Microsoft.WindowsAzure.Management (4.1.1)
       Microsoft.Azure.Common (>= 2.0.4 < 3.0)
     Microsoft.WindowsAzure.Management.Compute (12.3.1)
@@ -103,10 +103,12 @@ NUGET
     Microsoft.WindowsAzure.Management.WebSites (4.0.0)
       Microsoft.WindowsAzure.Common (>= 1.3.0 < 2.0)
     Mono.Cecil (0.9.6.1)
-    Newtonsoft.Json (7.0.1)
+    Newtonsoft.Json (7.0.1) - framework: wpv8.0, >= net40
     NuGet.CommandLine (2.8.6)
     NUnit (2.6.4)
     NUnit.Runners (2.6.4)
+    Octokit (0.16.0)
+      Microsoft.Net.Http
     Streams (0.4.1)
     System.Spatial (5.6.4) - framework: winv4.5, wpv8.1, wpv8.0, >= net40
     TaskParallelLibrary (1.0.2856) - framework: net35
@@ -120,3 +122,8 @@ NUGET
       Microsoft.Data.Services.Client (>= 5.6.2) - framework: >= net40
       Microsoft.WindowsAzure.ConfigurationManager (>= 1.8.0.0) - framework: >= net40
       Newtonsoft.Json (>= 5.0.8) - framework: wpv8.0, >= net40
+GITHUB
+  remote: fsharp/FAKE
+  specs:
+    modules/Octokit/Octokit.fsx (494c549c61dc15ab798b7b92cb4ac6e981267f49)
+      Octokit

--- a/samples/MBrace.Azure.CloudService/MBrace.Azure.CloudService.ccproj
+++ b/samples/MBrace.Azure.CloudService/MBrace.Azure.CloudService.ccproj
@@ -10,8 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MBrace.Azure.CloudService</RootNamespace>
     <AssemblyName>MBrace.Azure.CloudService</AssemblyName>
-    <StartDevelopmentStorage>True</StartDevelopmentStorage>
     <Name>MBrace.Azure.CloudService</Name>
+    <ServiceVMSize Condition=" '$(ServiceVMSize)' == '' ">Large</ServiceVMSize>
+    <PackageEnableRemoteDebugger>False</PackageEnableRemoteDebugger>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,7 +33,7 @@
   </PropertyGroup>
   <!-- Items for the project -->
   <ItemGroup>
-    <ServiceDefinition Include="ServiceDefinition.csdef" />
+    <ServiceDefinition Include="ServiceDefinition$(ServiceVMSize).csdef" />
     <ServiceConfiguration Include="ServiceConfiguration.Local.cscfg" />
     <ServiceConfiguration Include="ServiceConfiguration.Cloud.cscfg" />
   </ItemGroup>

--- a/samples/MBrace.Azure.CloudService/ServiceConfiguration.Cloud.cscfg
+++ b/samples/MBrace.Azure.CloudService/ServiceConfiguration.Cloud.cscfg
@@ -5,7 +5,7 @@
     <ConfigurationSettings>
       <Setting name="MBrace.StorageConnectionString" value="" />
       <Setting name="MBrace.ServiceBusConnectionString" value="" />
-      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="UseDevelopmentStorage=true" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="" />
     </ConfigurationSettings>
   </Role>
 </ServiceConfiguration>

--- a/samples/MBrace.Azure.CloudService/ServiceDefinition.csdef
+++ b/samples/MBrace.Azure.CloudService/ServiceDefinition.csdef
@@ -1,13 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ServiceDefinition name="MBrace.Azure.CloudService" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceDefinition" schemaVersion="2015-04.2.6">
-  <WorkerRole name="MBrace.Azure.WorkerRole" vmsize="Medium">
-    <LocalResources>
-      <LocalStorage name="LocalMBraceCache" cleanOnRoleRecycle="true" sizeInMB="409600" />
-    </LocalResources>
-    <ConfigurationSettings>
-      <Setting name="MBrace.StorageConnectionString" />
-      <Setting name="MBrace.ServiceBusConnectionString" />
-      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" />
-    </ConfigurationSettings>
-  </WorkerRole>
+	<WorkerRole name="MBrace.Azure.WorkerRole" vmsize="Large">
+		<LocalResources>
+			<LocalStorage name="LocalMBraceCache" cleanOnRoleRecycle="true" sizeInMB="409600" />
+		</LocalResources>
+		<ConfigurationSettings>
+			<Setting name="MBrace.StorageConnectionString" />
+			<Setting name="MBrace.ServiceBusConnectionString" />
+			<Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" />
+		</ConfigurationSettings>
+		<Endpoints>
+			<InputEndpoint name="DefaultHttpEndpoint" protocol="http" port="80" />
+			<InputEndpoint name="MBraceStats" protocol="http" port="8083" />
+			<InputEndpoint name="DefaultTcpEndpoint" protocol="tcp" port="10100" />
+			<!-- <InputEndpoint name="DefaultHttpsEndpoint" protocol="https" port="443" certificate="SSL"/> -->
+			<!-- <InputEndpoint name="DefaultNetTcpEndpoint" protocol="tcp" port="808" certificate="SSL"/> -->
+		</Endpoints>
+	</WorkerRole>
 </ServiceDefinition>

--- a/samples/MBrace.Azure.WorkerRole/MBrace.Azure.WorkerRole.csproj
+++ b/samples/MBrace.Azure.WorkerRole/MBrace.Azure.WorkerRole.csproj
@@ -401,24 +401,6 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json">
-          <HintPath>..\..\packages\Newtonsoft.Json\lib\net35\Newtonsoft.Json.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0')">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json">
-          <HintPath>..\..\packages\Newtonsoft.Json\lib\net20\Newtonsoft.Json.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="Newtonsoft.Json">
@@ -437,16 +419,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile259')">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json">
-          <HintPath>..\..\packages\Newtonsoft.Json\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkProfile) == 'Profile5') Or ($(TargetFrameworkProfile) == 'Profile6') Or ($(TargetFrameworkProfile) == 'Profile14') Or ($(TargetFrameworkProfile) == 'Profile19') Or ($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile37') Or ($(TargetFrameworkProfile) == 'Profile42') Or ($(TargetFrameworkProfile) == 'Profile47') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile92') Or ($(TargetFrameworkProfile) == 'Profile102') Or ($(TargetFrameworkProfile) == 'Profile136') Or ($(TargetFrameworkProfile) == 'Profile147') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile158') Or ($(TargetFrameworkProfile) == 'Profile225') Or ($(TargetFrameworkProfile) == 'Profile240') Or ($(TargetFrameworkProfile) == 'Profile255') Or ($(TargetFrameworkProfile) == 'Profile328') Or ($(TargetFrameworkProfile) == 'Profile336') Or ($(TargetFrameworkProfile) == 'Profile344')">
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v8.0'">
       <ItemGroup>
         <Reference Include="Newtonsoft.Json">
           <HintPath>..\..\packages\Newtonsoft.Json\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>

--- a/samples/MBrace.Azure.WorkerRole/Properties/AssemblyInfo.cs
+++ b/samples/MBrace.Azure.WorkerRole/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 [assembly: AssemblyCompanyAttribute("Nessos Information Technologies")]
 [assembly: AssemblyCopyrightAttribute("© Nessos Information Technologies.")]
 [assembly: AssemblyTrademarkAttribute("MBrace")]
-[assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 005fcf, Build Date 30102015 03:20 +00:00")]
+[assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 6d67ca, Build Date 30102015 13:49 +00:00")]
 [assembly: AssemblyVersionAttribute("0.16.0")]
 [assembly: AssemblyFileVersionAttribute("0.16.0")]
 namespace System {

--- a/samples/MBrace.Azure.WorkerRole/Properties/AssemblyInfo.cs
+++ b/samples/MBrace.Azure.WorkerRole/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 [assembly: AssemblyCompanyAttribute("Nessos Information Technologies")]
 [assembly: AssemblyCopyrightAttribute("© Nessos Information Technologies.")]
 [assembly: AssemblyTrademarkAttribute("MBrace")]
-[assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 3880d9, Build Date 30102015 03:10 +00:00")]
+[assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 005fcf, Build Date 30102015 03:20 +00:00")]
 [assembly: AssemblyVersionAttribute("0.16.0")]
 [assembly: AssemblyFileVersionAttribute("0.16.0")]
 namespace System {

--- a/samples/MBrace.Azure.WorkerRole/Properties/AssemblyInfo.cs
+++ b/samples/MBrace.Azure.WorkerRole/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 [assembly: AssemblyCompanyAttribute("Nessos Information Technologies")]
 [assembly: AssemblyCopyrightAttribute("© Nessos Information Technologies.")]
 [assembly: AssemblyTrademarkAttribute("MBrace")]
-[assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash aa2889, Build Date 26102015 17:15 +02:00")]
+[assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 3880d9, Build Date 30102015 03:10 +00:00")]
 [assembly: AssemblyVersionAttribute("0.16.0")]
 [assembly: AssemblyFileVersionAttribute("0.16.0")]
 namespace System {

--- a/samples/MBrace.Azure.WorkerRole/app.config
+++ b/samples/MBrace.Azure.WorkerRole/app.config
@@ -59,6 +59,86 @@
     <assemblyIdentity name="Mono.Cecil" publicKeyToken="0738eb9f132ed756" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="0.9.6.0" />
   </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Hyak.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Azure.Common.NetFramework" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Azure.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Threading.Tasks.Extensions.Desktop" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.168.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Threading.Tasks.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.12.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.12.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="System.Net.Http.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.2.29.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.2.29.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Common.NetFramework" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Compute" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="12.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.MediaServices" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Monitoring" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Network" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="7.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Scheduler" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="6.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="0.9.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Sql" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="5.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="5.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.WebSites" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.0.0.0" />
+  </dependentAssembly>
 </assemblyBinding></runtime>
     <system.diagnostics>
         <trace>

--- a/src/MBrace.Azure.StandaloneWorker/App.config
+++ b/src/MBrace.Azure.StandaloneWorker/App.config
@@ -83,6 +83,86 @@
     <assemblyIdentity name="Mono.Cecil" publicKeyToken="0738eb9f132ed756" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="0.9.6.0" />
   </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Hyak.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Azure.Common.NetFramework" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Azure.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Threading.Tasks.Extensions.Desktop" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.168.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Threading.Tasks.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.12.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.12.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="System.Net.Http.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.2.29.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.2.29.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Common.NetFramework" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Compute" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="12.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.MediaServices" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Monitoring" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Network" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="7.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Scheduler" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="6.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="0.9.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Sql" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="5.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="5.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.WebSites" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.0.0.0" />
+  </dependentAssembly>
 </assemblyBinding></runtime>
   <system.serviceModel>
     <extensions>

--- a/src/MBrace.Azure.StandaloneWorker/AssemblyInfo.fs
+++ b/src/MBrace.Azure.StandaloneWorker/AssemblyInfo.fs
@@ -6,7 +6,7 @@ open System.Reflection
 [<assembly: AssemblyCompanyAttribute("Nessos Information Technologies")>]
 [<assembly: AssemblyCopyrightAttribute("© Nessos Information Technologies.")>]
 [<assembly: AssemblyTrademarkAttribute("MBrace")>]
-[<assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 3880d9, Build Date 30102015 03:10 +00:00")>]
+[<assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 005fcf, Build Date 30102015 03:20 +00:00")>]
 [<assembly: AssemblyVersionAttribute("0.16.0")>]
 [<assembly: AssemblyFileVersionAttribute("0.16.0")>]
 do ()

--- a/src/MBrace.Azure.StandaloneWorker/AssemblyInfo.fs
+++ b/src/MBrace.Azure.StandaloneWorker/AssemblyInfo.fs
@@ -6,7 +6,7 @@ open System.Reflection
 [<assembly: AssemblyCompanyAttribute("Nessos Information Technologies")>]
 [<assembly: AssemblyCopyrightAttribute("© Nessos Information Technologies.")>]
 [<assembly: AssemblyTrademarkAttribute("MBrace")>]
-[<assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 005fcf, Build Date 30102015 03:20 +00:00")>]
+[<assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 6d67ca, Build Date 30102015 13:49 +00:00")>]
 [<assembly: AssemblyVersionAttribute("0.16.0")>]
 [<assembly: AssemblyFileVersionAttribute("0.16.0")>]
 do ()

--- a/src/MBrace.Azure.StandaloneWorker/AssemblyInfo.fs
+++ b/src/MBrace.Azure.StandaloneWorker/AssemblyInfo.fs
@@ -6,7 +6,7 @@ open System.Reflection
 [<assembly: AssemblyCompanyAttribute("Nessos Information Technologies")>]
 [<assembly: AssemblyCopyrightAttribute("© Nessos Information Technologies.")>]
 [<assembly: AssemblyTrademarkAttribute("MBrace")>]
-[<assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash aa2889, Build Date 26102015 17:15 +02:00")>]
+[<assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 3880d9, Build Date 30102015 03:10 +00:00")>]
 [<assembly: AssemblyVersionAttribute("0.16.0")>]
 [<assembly: AssemblyFileVersionAttribute("0.16.0")>]
 do ()

--- a/src/MBrace.Azure.StandaloneWorker/MBrace.Azure.StandaloneWorker.fsproj
+++ b/src/MBrace.Azure.StandaloneWorker/MBrace.Azure.StandaloneWorker.fsproj
@@ -340,24 +340,6 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json">
-          <HintPath>..\..\packages\Newtonsoft.Json\lib\net35\Newtonsoft.Json.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0')">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json">
-          <HintPath>..\..\packages\Newtonsoft.Json\lib\net20\Newtonsoft.Json.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="Newtonsoft.Json">
@@ -376,16 +358,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile259')">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json">
-          <HintPath>..\..\packages\Newtonsoft.Json\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkProfile) == 'Profile5') Or ($(TargetFrameworkProfile) == 'Profile6') Or ($(TargetFrameworkProfile) == 'Profile14') Or ($(TargetFrameworkProfile) == 'Profile19') Or ($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile37') Or ($(TargetFrameworkProfile) == 'Profile42') Or ($(TargetFrameworkProfile) == 'Profile47') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile92') Or ($(TargetFrameworkProfile) == 'Profile102') Or ($(TargetFrameworkProfile) == 'Profile136') Or ($(TargetFrameworkProfile) == 'Profile147') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile158') Or ($(TargetFrameworkProfile) == 'Profile225') Or ($(TargetFrameworkProfile) == 'Profile240') Or ($(TargetFrameworkProfile) == 'Profile255') Or ($(TargetFrameworkProfile) == 'Profile328') Or ($(TargetFrameworkProfile) == 'Profile336') Or ($(TargetFrameworkProfile) == 'Profile344')">
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v8.0'">
       <ItemGroup>
         <Reference Include="Newtonsoft.Json">
           <HintPath>..\..\packages\Newtonsoft.Json\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>

--- a/src/MBrace.Azure/AssemblyInfo.fs
+++ b/src/MBrace.Azure/AssemblyInfo.fs
@@ -6,7 +6,7 @@ open System.Reflection
 [<assembly: AssemblyCompanyAttribute("Nessos Information Technologies")>]
 [<assembly: AssemblyCopyrightAttribute("© Nessos Information Technologies.")>]
 [<assembly: AssemblyTrademarkAttribute("MBrace")>]
-[<assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 3880d9, Build Date 30102015 03:10 +00:00")>]
+[<assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 005fcf, Build Date 30102015 03:20 +00:00")>]
 [<assembly: AssemblyVersionAttribute("0.16.0")>]
 [<assembly: AssemblyFileVersionAttribute("0.16.0")>]
 do ()

--- a/src/MBrace.Azure/AssemblyInfo.fs
+++ b/src/MBrace.Azure/AssemblyInfo.fs
@@ -6,7 +6,7 @@ open System.Reflection
 [<assembly: AssemblyCompanyAttribute("Nessos Information Technologies")>]
 [<assembly: AssemblyCopyrightAttribute("© Nessos Information Technologies.")>]
 [<assembly: AssemblyTrademarkAttribute("MBrace")>]
-[<assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 005fcf, Build Date 30102015 03:20 +00:00")>]
+[<assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 6d67ca, Build Date 30102015 13:49 +00:00")>]
 [<assembly: AssemblyVersionAttribute("0.16.0")>]
 [<assembly: AssemblyFileVersionAttribute("0.16.0")>]
 do ()

--- a/src/MBrace.Azure/AssemblyInfo.fs
+++ b/src/MBrace.Azure/AssemblyInfo.fs
@@ -6,7 +6,7 @@ open System.Reflection
 [<assembly: AssemblyCompanyAttribute("Nessos Information Technologies")>]
 [<assembly: AssemblyCopyrightAttribute("© Nessos Information Technologies.")>]
 [<assembly: AssemblyTrademarkAttribute("MBrace")>]
-[<assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash aa2889, Build Date 26102015 17:15 +02:00")>]
+[<assembly: AssemblyMetadataAttribute("Release Signature","Version 0.16.0, Git Hash 3880d9, Build Date 30102015 03:10 +00:00")>]
 [<assembly: AssemblyVersionAttribute("0.16.0")>]
 [<assembly: AssemblyFileVersionAttribute("0.16.0")>]
 do ()

--- a/src/MBrace.Azure/MBrace.Azure.fsproj
+++ b/src/MBrace.Azure/MBrace.Azure.fsproj
@@ -118,6 +118,8 @@
     <Compile Include="Runtime\Service.fs" />
     <Compile Include="Runtime\StandaloneWorker.fs" />
     <Compile Include="Runtime\Client.fs" />
+    <Compile Include="Management.fsi" />
+    <Compile Include="Management.fs" />
     <Content Include="paket.references" />
     <None Include="paket.template" />
   </ItemGroup>
@@ -127,6 +129,9 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Threading.Tasks" />
+    <Reference Include="System.ServiceModel.Discovery" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Management" />
@@ -215,6 +220,35 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
+      <ItemGroup>
+        <Reference Include="Hyak.Common">
+          <HintPath>..\..\packages\Hyak.Common\lib\net40\Hyak.Common.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Hyak.Common">
+          <HintPath>..\..\packages\Hyak.Common\lib\net45\Hyak.Common.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile5') Or ($(TargetFrameworkProfile) == 'Profile6') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile92') Or ($(TargetFrameworkProfile) == 'Profile102') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151')">
+      <ItemGroup>
+        <Reference Include="Hyak.Common">
+          <HintPath>..\..\packages\Hyak.Common\lib\portable-net403+win+wpa81\Hyak.Common.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="MBrace.Core">
@@ -230,6 +264,288 @@
       <ItemGroup>
         <Reference Include="MBrace.Runtime">
           <HintPath>..\..\packages\MBrace.Runtime\lib\net45\MBrace.Runtime.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Azure.Common.NetFramework">
+          <HintPath>..\..\packages\Microsoft.Azure.Common\lib\net40\Microsoft.Azure.Common.NetFramework.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Azure.Common">
+          <HintPath>..\..\packages\Microsoft.Azure.Common\lib\net40\Microsoft.Azure.Common.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Azure.Common.NetFramework">
+          <HintPath>..\..\packages\Microsoft.Azure.Common\lib\net45\Microsoft.Azure.Common.NetFramework.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Azure.Common">
+          <HintPath>..\..\packages\Microsoft.Azure.Common\lib\net45\Microsoft.Azure.Common.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Azure.Common">
+          <HintPath>..\..\packages\Microsoft.Azure.Common\lib\portable-net45+wp8+wpa81+win\Microsoft.Azure.Common.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\Microsoft.Bcl\lib\net40\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v4.0'">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\Microsoft.Bcl\lib\sl4\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0'">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\Microsoft.Bcl\lib\sl5\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v7.1'">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\Microsoft.Bcl\lib\sl4-windowsphone71\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkProfile) == 'Profile14') Or ($(TargetFrameworkProfile) == 'Profile19') Or ($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile37') Or ($(TargetFrameworkProfile) == 'Profile42') Or ($(TargetFrameworkProfile) == 'Profile47') Or ($(TargetFrameworkProfile) == 'Profile136') Or ($(TargetFrameworkProfile) == 'Profile147') Or ($(TargetFrameworkProfile) == 'Profile158') Or ($(TargetFrameworkProfile) == 'Profile225') Or ($(TargetFrameworkProfile) == 'Profile240') Or ($(TargetFrameworkProfile) == 'Profile255') Or ($(TargetFrameworkProfile) == 'Profile328') Or ($(TargetFrameworkProfile) == 'Profile336') Or ($(TargetFrameworkProfile) == 'Profile344')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\Microsoft.Bcl\lib\portable-net40+sl5+win8+wp8+wpa81\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkProfile) == 'Profile3') Or ($(TargetFrameworkProfile) == 'Profile18') Or ($(TargetFrameworkProfile) == 'Profile23') Or ($(TargetFrameworkProfile) == 'Profile41') Or ($(TargetFrameworkProfile) == 'Profile46')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\Microsoft.Bcl\lib\portable-net40+sl4+win8\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile92') Or ($(TargetFrameworkProfile) == 'Profile102') Or ($(TargetFrameworkProfile) == 'Profile157')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\Microsoft.Bcl\lib\portable-net40+win8+wp8+wpa81\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkProfile) == 'Profile36') Or ($(TargetFrameworkProfile) == 'Profile143') Or ($(TargetFrameworkProfile) == 'Profile154')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\Microsoft.Bcl\lib\portable-net40+sl4+win8+wp8+wpa81\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkProfile) == 'Profile5') Or ($(TargetFrameworkProfile) == 'Profile6')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\Microsoft.Bcl\lib\portable-net40+win8\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkProfile) == 'Profile88') Or ($(TargetFrameworkProfile) == 'Profile96') Or ($(TargetFrameworkProfile) == 'Profile104')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\Microsoft.Bcl\lib\portable-net40+sl4+win8+wp71+wpa81\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETCore'">
+      <ItemGroup>
+        <Reference Include="Microsoft.Threading.Tasks.Extensions">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\win8\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Threading.Tasks">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\win8\Microsoft.Threading.Tasks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Threading.Tasks.Extensions">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Threading.Tasks">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Silverlight' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v5.0')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Threading.Tasks.Extensions.Silverlight">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\sl4\Microsoft.Threading.Tasks.Extensions.Silverlight.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Threading.Tasks.Extensions">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\sl4\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Threading.Tasks">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\sl4\Microsoft.Threading.Tasks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v7.1'">
+      <ItemGroup>
+        <Reference Include="Microsoft.Threading.Tasks.Extensions.Phone">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\sl4-windowsphone71\Microsoft.Threading.Tasks.Extensions.Phone.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Threading.Tasks.Extensions">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\sl4-windowsphone71\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Threading.Tasks">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\sl4-windowsphone71\Microsoft.Threading.Tasks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Threading.Tasks.Extensions.Phone">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\wp8\Microsoft.Threading.Tasks.Extensions.Phone.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Threading.Tasks.Extensions">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\wp8\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Threading.Tasks">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\wp8\Microsoft.Threading.Tasks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhoneApp'">
+      <ItemGroup>
+        <Reference Include="Microsoft.Threading.Tasks.Extensions">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Threading.Tasks">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\wpa81\Microsoft.Threading.Tasks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Threading.Tasks.Extensions">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\portable-net45+win8+wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Threading.Tasks">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\portable-net45+win8+wpa81\Microsoft.Threading.Tasks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkProfile) == 'Profile3') Or ($(TargetFrameworkProfile) == 'Profile5') Or ($(TargetFrameworkProfile) == 'Profile6') Or ($(TargetFrameworkProfile) == 'Profile14') Or ($(TargetFrameworkProfile) == 'Profile18') Or ($(TargetFrameworkProfile) == 'Profile19') Or ($(TargetFrameworkProfile) == 'Profile23') Or ($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile36') Or ($(TargetFrameworkProfile) == 'Profile37') Or ($(TargetFrameworkProfile) == 'Profile41') Or ($(TargetFrameworkProfile) == 'Profile42') Or ($(TargetFrameworkProfile) == 'Profile46') Or ($(TargetFrameworkProfile) == 'Profile47') Or ($(TargetFrameworkProfile) == 'Profile88') Or ($(TargetFrameworkProfile) == 'Profile92') Or ($(TargetFrameworkProfile) == 'Profile96') Or ($(TargetFrameworkProfile) == 'Profile102') Or ($(TargetFrameworkProfile) == 'Profile104') Or ($(TargetFrameworkProfile) == 'Profile136') Or ($(TargetFrameworkProfile) == 'Profile143') Or ($(TargetFrameworkProfile) == 'Profile147') Or ($(TargetFrameworkProfile) == 'Profile154') Or ($(TargetFrameworkProfile) == 'Profile158') Or ($(TargetFrameworkProfile) == 'Profile225') Or ($(TargetFrameworkProfile) == 'Profile240') Or ($(TargetFrameworkProfile) == 'Profile255') Or ($(TargetFrameworkProfile) == 'Profile328') Or ($(TargetFrameworkProfile) == 'Profile336') Or ($(TargetFrameworkProfile) == 'Profile344')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Threading.Tasks.Extensions">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\portable-net40+sl4+win8+wp71+wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Threading.Tasks">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\portable-net40+sl4+win8+wp71+wpa81\Microsoft.Threading.Tasks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Threading.Tasks.Extensions">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\portable-net45+win8+wp8+wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.Threading.Tasks">
+          <HintPath>..\..\packages\Microsoft.Bcl.Async\lib\portable-net45+win8+wp8+wpa81\Microsoft.Threading.Tasks.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
@@ -288,10 +604,384 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
+      <ItemGroup>
+        <Reference Include="System.Net.Http.Extensions">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\net40\System.Net.Http.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\net40\System.Net.Http.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.WebRequest">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\net40\System.Net.Http.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="System.Net.Http.Extensions">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.WebRequest">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkProfile) == 'Profile3') Or ($(TargetFrameworkProfile) == 'Profile5') Or ($(TargetFrameworkProfile) == 'Profile6') Or ($(TargetFrameworkProfile) == 'Profile14') Or ($(TargetFrameworkProfile) == 'Profile18') Or ($(TargetFrameworkProfile) == 'Profile19') Or ($(TargetFrameworkProfile) == 'Profile23') Or ($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile36') Or ($(TargetFrameworkProfile) == 'Profile37') Or ($(TargetFrameworkProfile) == 'Profile41') Or ($(TargetFrameworkProfile) == 'Profile42') Or ($(TargetFrameworkProfile) == 'Profile46') Or ($(TargetFrameworkProfile) == 'Profile47') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile88') Or ($(TargetFrameworkProfile) == 'Profile92') Or ($(TargetFrameworkProfile) == 'Profile96') Or ($(TargetFrameworkProfile) == 'Profile102') Or ($(TargetFrameworkProfile) == 'Profile104') Or ($(TargetFrameworkProfile) == 'Profile136') Or ($(TargetFrameworkProfile) == 'Profile143') Or ($(TargetFrameworkProfile) == 'Profile147') Or ($(TargetFrameworkProfile) == 'Profile154') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile158') Or ($(TargetFrameworkProfile) == 'Profile225') Or ($(TargetFrameworkProfile) == 'Profile240') Or ($(TargetFrameworkProfile) == 'Profile255') Or ($(TargetFrameworkProfile) == 'Profile259') Or ($(TargetFrameworkProfile) == 'Profile328') Or ($(TargetFrameworkProfile) == 'Profile336') Or ($(TargetFrameworkProfile) == 'Profile344')">
+      <ItemGroup>
+        <Reference Include="System.Net.Http.Extensions">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151')">
+      <ItemGroup>
+        <Reference Include="System.Net.Http.Extensions">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\portable-net45+win8+wpa81\System.Net.Http.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\portable-net45+win8+wpa81\System.Net.Http.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
+      <ItemGroup>
+        <Reference Include="System.Net.Http.Extensions">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\portable-net45+win8\System.Net.Http.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\portable-net45+win8\System.Net.Http.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETCore'">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Common.WindowsStore">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Common\lib\windows8\Microsoft.WindowsAzure.Common.WindowsStore.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.WindowsAzure.Common">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Common\lib\windows8\Microsoft.WindowsAzure.Common.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Common.NetFramework">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Common\lib\net40\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.WindowsAzure.Common">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Common\lib\net40\Microsoft.WindowsAzure.Common.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Common.NetFramework">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Common\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.WindowsAzure.Common">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Common\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Common.WindowsPhone">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Common\lib\wp8\Microsoft.WindowsAzure.Common.WindowsPhone.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.WindowsAzure.Common">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Common\lib\wp8\Microsoft.WindowsAzure.Common.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhoneApp'">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Common.WindowsPhone81">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Common\lib\wpa81\Microsoft.WindowsAzure.Common.WindowsPhone81.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Microsoft.WindowsAzure.Common">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Common\lib\wpa81\Microsoft.WindowsAzure.Common.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Common">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Common\lib\portable-net45+wp8+wpa81+win\Microsoft.WindowsAzure.Common.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
         <Reference Include="Microsoft.WindowsAzure.Configuration">
           <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management\lib\net40\Microsoft.WindowsAzure.Management.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management\lib\portable-net45+wp8+wpa81+win\Microsoft.WindowsAzure.Management.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.Compute">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Compute\lib\net40\Microsoft.WindowsAzure.Management.Compute.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.Compute">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Compute\lib\portable-net45+wp8+wpa81+win\Microsoft.WindowsAzure.Management.Compute.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.MediaServices">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.MediaServices\lib\net40\Microsoft.WindowsAzure.Management.MediaServices.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.MediaServices">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.MediaServices\lib\portable-net45+wp8+wpa81+win\Microsoft.WindowsAzure.Management.MediaServices.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.Monitoring">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Monitoring\lib\net40\Microsoft.WindowsAzure.Management.Monitoring.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.Monitoring">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Monitoring\lib\portable-net45+wp8+wpa81+win\Microsoft.WindowsAzure.Management.Monitoring.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.Network">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Network\lib\net40\Microsoft.WindowsAzure.Management.Network.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.Network">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Network\lib\portable-net45+wp8+wpa81+win\Microsoft.WindowsAzure.Management.Network.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.Scheduler">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Scheduler\lib\net40\Microsoft.WindowsAzure.Management.Scheduler.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.Scheduler">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Scheduler\lib\portable-net45+wp8+wpa81+win\Microsoft.WindowsAzure.Management.Scheduler.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.ServiceBus">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.ServiceBus\lib\net40\Microsoft.WindowsAzure.Management.ServiceBus.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.ServiceBus">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.ServiceBus\lib\portable-net45+wp8+wpa81+win\Microsoft.WindowsAzure.Management.ServiceBus.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.Sql">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Sql\lib\net40\Microsoft.WindowsAzure.Management.Sql.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.Sql">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Sql\lib\portable-net45+wp8+wpa81+win\Microsoft.WindowsAzure.Management.Sql.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.Storage">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Storage\lib\net40\Microsoft.WindowsAzure.Management.Storage.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.Storage">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Storage\lib\portable-net45+wp8+wpa81+win\Microsoft.WindowsAzure.Management.Storage.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.WebSites">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.WebSites\lib\net40\Microsoft.WindowsAzure.Management.WebSites.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile47') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile158')">
+      <ItemGroup>
+        <Reference Include="Microsoft.WindowsAzure.Management.WebSites">
+          <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.WebSites\lib\portable-net45+sl50+wp80+win\Microsoft.WindowsAzure.Management.WebSites.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/MBrace.Azure/MBrace.Azure.fsproj
+++ b/src/MBrace.Azure/MBrace.Azure.fsproj
@@ -604,6 +604,20 @@
     </When>
   </Choose>
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETCore'">
+      <ItemGroup>
+        <Reference Include="System.Net.Http.Extensions">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\win8\System.Net.Http.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\win8\System.Net.Http.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="System.Net.Http.Extensions">
@@ -648,7 +662,88 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="($(TargetFrameworkProfile) == 'Profile3') Or ($(TargetFrameworkProfile) == 'Profile5') Or ($(TargetFrameworkProfile) == 'Profile6') Or ($(TargetFrameworkProfile) == 'Profile14') Or ($(TargetFrameworkProfile) == 'Profile18') Or ($(TargetFrameworkProfile) == 'Profile19') Or ($(TargetFrameworkProfile) == 'Profile23') Or ($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile36') Or ($(TargetFrameworkProfile) == 'Profile37') Or ($(TargetFrameworkProfile) == 'Profile41') Or ($(TargetFrameworkProfile) == 'Profile42') Or ($(TargetFrameworkProfile) == 'Profile46') Or ($(TargetFrameworkProfile) == 'Profile47') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile88') Or ($(TargetFrameworkProfile) == 'Profile92') Or ($(TargetFrameworkProfile) == 'Profile96') Or ($(TargetFrameworkProfile) == 'Profile102') Or ($(TargetFrameworkProfile) == 'Profile104') Or ($(TargetFrameworkProfile) == 'Profile136') Or ($(TargetFrameworkProfile) == 'Profile143') Or ($(TargetFrameworkProfile) == 'Profile147') Or ($(TargetFrameworkProfile) == 'Profile154') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile158') Or ($(TargetFrameworkProfile) == 'Profile225') Or ($(TargetFrameworkProfile) == 'Profile240') Or ($(TargetFrameworkProfile) == 'Profile255') Or ($(TargetFrameworkProfile) == 'Profile259') Or ($(TargetFrameworkProfile) == 'Profile328') Or ($(TargetFrameworkProfile) == 'Profile336') Or ($(TargetFrameworkProfile) == 'Profile344')">
+    <When Condition="$(TargetFrameworkIdentifier) == 'MonoAndroid'">
+      <ItemGroup>
+        <Reference Include="System.Net.Http.Extensions">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\monoandroid\System.Net.Http.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\monoandroid\System.Net.Http.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'MonoTouch'">
+      <ItemGroup>
+        <Reference Include="System.Net.Http.Extensions">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\monotouch\System.Net.Http.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\monotouch\System.Net.Http.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v7.1' Or $(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')">
+      <ItemGroup>
+        <Reference Include="System.Net.Http.Extensions">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\sl4-windowsphone71\System.Net.Http.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\sl4-windowsphone71\System.Net.Http.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\sl4-windowsphone71\System.Net.Http.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhoneApp'">
+      <ItemGroup>
+        <Reference Include="System.Net.Http.Extensions">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\wpa81\System.Net.Http.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\wpa81\System.Net.Http.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Xamarin.iOS'">
+      <ItemGroup>
+        <Reference Include="System.Net.Http.Extensions">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\Xamarin.iOS10\System.Net.Http.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\Xamarin.iOS10\System.Net.Http.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'Silverlight' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v5.0')) Or ($(TargetFrameworkProfile) == 'Profile3') Or ($(TargetFrameworkProfile) == 'Profile5') Or ($(TargetFrameworkProfile) == 'Profile6') Or ($(TargetFrameworkProfile) == 'Profile14') Or ($(TargetFrameworkProfile) == 'Profile18') Or ($(TargetFrameworkProfile) == 'Profile19') Or ($(TargetFrameworkProfile) == 'Profile23') Or ($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile36') Or ($(TargetFrameworkProfile) == 'Profile37') Or ($(TargetFrameworkProfile) == 'Profile41') Or ($(TargetFrameworkProfile) == 'Profile42') Or ($(TargetFrameworkProfile) == 'Profile46') Or ($(TargetFrameworkProfile) == 'Profile47') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile88') Or ($(TargetFrameworkProfile) == 'Profile92') Or ($(TargetFrameworkProfile) == 'Profile96') Or ($(TargetFrameworkProfile) == 'Profile102') Or ($(TargetFrameworkProfile) == 'Profile104') Or ($(TargetFrameworkProfile) == 'Profile136') Or ($(TargetFrameworkProfile) == 'Profile143') Or ($(TargetFrameworkProfile) == 'Profile147') Or ($(TargetFrameworkProfile) == 'Profile154') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile158') Or ($(TargetFrameworkProfile) == 'Profile225') Or ($(TargetFrameworkProfile) == 'Profile240') Or ($(TargetFrameworkProfile) == 'Profile255') Or ($(TargetFrameworkProfile) == 'Profile259') Or ($(TargetFrameworkProfile) == 'Profile328') Or ($(TargetFrameworkProfile) == 'Profile336') Or ($(TargetFrameworkProfile) == 'Profile344')">
       <ItemGroup>
         <Reference Include="System.Net.Http.Extensions">
           <HintPath>..\..\packages\Microsoft.Net.Http\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Extensions.dll</HintPath>
@@ -667,6 +762,20 @@
         </Reference>
       </ItemGroup>
     </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
+      <ItemGroup>
+        <Reference Include="System.Net.Http.Extensions">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\portable-net45+win8\System.Net.Http.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Net.Http.Primitives">
+          <HintPath>..\..\packages\Microsoft.Net.Http\lib\portable-net45+win8\System.Net.Http.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
     <When Condition="($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151')">
       <ItemGroup>
         <Reference Include="System.Net.Http.Extensions">
@@ -676,20 +785,6 @@
         </Reference>
         <Reference Include="System.Net.Http.Primitives">
           <HintPath>..\..\packages\Microsoft.Net.Http\lib\portable-net45+win8+wpa81\System.Net.Http.Primitives.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
-      <ItemGroup>
-        <Reference Include="System.Net.Http.Extensions">
-          <HintPath>..\..\packages\Microsoft.Net.Http\lib\portable-net45+win8\System.Net.Http.Extensions.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="System.Net.Http.Primitives">
-          <HintPath>..\..\packages\Microsoft.Net.Http\lib\portable-net45+win8\System.Net.Http.Primitives.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
@@ -1096,24 +1191,6 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json">
-          <HintPath>..\..\packages\Newtonsoft.Json\lib\net35\Newtonsoft.Json.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0')">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json">
-          <HintPath>..\..\packages\Newtonsoft.Json\lib\net20\Newtonsoft.Json.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="Newtonsoft.Json">
@@ -1132,16 +1209,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile259')">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json">
-          <HintPath>..\..\packages\Newtonsoft.Json\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkProfile) == 'Profile5') Or ($(TargetFrameworkProfile) == 'Profile6') Or ($(TargetFrameworkProfile) == 'Profile14') Or ($(TargetFrameworkProfile) == 'Profile19') Or ($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile37') Or ($(TargetFrameworkProfile) == 'Profile42') Or ($(TargetFrameworkProfile) == 'Profile47') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile92') Or ($(TargetFrameworkProfile) == 'Profile102') Or ($(TargetFrameworkProfile) == 'Profile136') Or ($(TargetFrameworkProfile) == 'Profile147') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile158') Or ($(TargetFrameworkProfile) == 'Profile225') Or ($(TargetFrameworkProfile) == 'Profile240') Or ($(TargetFrameworkProfile) == 'Profile255') Or ($(TargetFrameworkProfile) == 'Profile328') Or ($(TargetFrameworkProfile) == 'Profile336') Or ($(TargetFrameworkProfile) == 'Profile344')">
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v8.0'">
       <ItemGroup>
         <Reference Include="Newtonsoft.Json">
           <HintPath>..\..\packages\Newtonsoft.Json\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>

--- a/src/MBrace.Azure/Management.fs
+++ b/src/MBrace.Azure/Management.fs
@@ -1,7 +1,6 @@
 ﻿
 namespace MBrace.Azure
 
-open FSharp.Data
 open Microsoft.Azure
 open Microsoft.WindowsAzure.Management
 open Microsoft.WindowsAzure.Management.Compute
@@ -98,7 +97,7 @@ module private Trial =
 module private Details = 
 
     let resourcePrefix = "mbrace"
-    let generateResourceName() = resourcePrefix + (Guid.NewGuid().ToString() |> Seq.take 8 |> Seq.toArray |> String)
+    let generateResourceName() = resourcePrefix + (Guid.NewGuid().ToString() |> Seq.take 8 |> Seq.toArray |> (fun c -> String(c)))
     let defaultExtendedProperties = dict [ "IsMBraceAsset", "true"]
     let isMBraceAsset (extendedProperties:IDictionary<string, string>) = extendedProperties.ContainsKey "IsMBraceAsset"
 

--- a/src/MBrace.Azure/Management.fs
+++ b/src/MBrace.Azure/Management.fs
@@ -484,7 +484,8 @@ type Management() =
                | _ -> 
                    let mbraceVersion = defaultArg MBraceVersion mbracePackageVersion
                    do! info (sprintf "using MBrace version %s" mbraceVersion)
-                   let uri = defaultArg CloudServicePackage (sprintf "https://github.com/mbraceproject/MBrace.Azure/releases/download/%s/MBrace.Azure.CloudService-%s.cspkg" mbraceVersion vmSize)
+                   //let uri = defaultArg CloudServicePackage (sprintf "https://github.com/mbraceproject/MBrace.Azure/releases/download/%s/MBrace.Azure.CloudService-%s.cspkg" mbraceVersion vmSize)
+                   let uri = defaultArg CloudServicePackage (sprintf "https://github.com/mbraceproject/bits/raw/master/%s/MBrace.Azure.CloudService-%s.cspkg" mbraceVersion vmSize)
                    use wc = new System.Net.WebClient() 
                    let tmp = System.IO.Path.GetTempFileName() 
                    do! info (sprintf "downloading cloud service package from %s" uri)

--- a/src/MBrace.Azure/Management.fs
+++ b/src/MBrace.Azure/Management.fs
@@ -1,0 +1,535 @@
+﻿
+namespace MBrace.Azure
+
+open FSharp.Data
+open Microsoft.Azure
+open Microsoft.WindowsAzure.Management
+open Microsoft.WindowsAzure.Management.Compute
+open Microsoft.WindowsAzure.Management.Compute.Models
+open Microsoft.WindowsAzure.Management.Storage
+open Microsoft.WindowsAzure.Management.Storage.Models
+open Microsoft.WindowsAzure.Management.ServiceBus
+open System.Security.Cryptography.X509Certificates
+open System
+open System.IO
+open System.Xml.Linq
+open System.Collections.Generic
+
+/// Represents the result of a computation.
+type private Result<'TSuccess, 'TMessage> = 
+    /// Represents the result of a successful computation.
+    | Ok of 'TSuccess * 'TMessage list
+    /// Represents the result of a failed computation.
+    | Bad of 'TMessage list
+
+    /// Converts the result into a string.
+    override this.ToString() =
+        match this with
+        | Ok(v,msgs) -> sprintf "OK: %A - %s" v (String.Join(Environment.NewLine, msgs |> Seq.map (fun x -> x.ToString())))
+        | Bad(msgs) -> sprintf "Error: %s" (String.Join(Environment.NewLine, msgs |> Seq.map (fun x -> x.ToString())))    
+
+/// Basic combinators and operators for error handling.
+[<AutoOpen>]
+module private Trial =  
+    let ok x = Ok(x, [])
+    let pass x = Ok(x, [])
+    let info msg = printfn "%s" msg; Ok((),[msg])
+    let fail msg = printfn "Error: %s" msg; Bad([ msg ])
+    let protect f = (fun x -> try f x with e -> fail e.Message)
+    let either fSuccess fFailure trialResult = 
+        match trialResult with
+        | Ok(x, msgs) -> fSuccess (x, msgs)
+        | Bad(msgs) -> fFailure (msgs)
+
+    let returnOrFail result = 
+        let raiseExn msgs = 
+            msgs
+            |> Seq.map (sprintf "%O")
+            |> String.concat (Environment.NewLine + "   ")
+            |> failwith
+        either fst raiseExn result
+
+    let mergeMessages msgs result = 
+        let fSuccess (x, msgs2) = Ok(x, msgs @ msgs2)
+        let fFailure errs = Bad(errs @ msgs)
+        either fSuccess fFailure result
+
+    let bind f result = 
+        let fSuccess (x, msgs) = f x |> mergeMessages msgs
+        let fFailure (msgs) = Bad msgs
+        either fSuccess fFailure result
+
+    let apply wrappedFunction result = 
+        match wrappedFunction, result with
+        | Ok(f, msgs1), Ok(x, msgs2) -> Ok(f x, msgs1 @ msgs2)
+        | Bad errs, Ok _ -> Bad(errs)
+        | Ok _, Bad errs -> Bad(errs)
+        | Bad errs1, Bad errs2 -> Bad(errs1 @ errs2)
+
+    let lift f result = apply (ok f) result
+
+    /// Converts an option into a Result.
+    let failIfNone message result = 
+        match result with
+        | Some x -> ok x
+        | None -> fail message
+
+    /// Builder type for error handling computation expressions.
+    type TrialBuilder() = 
+        member __.Zero() = ok()
+        member __.Bind(m, f) = bind f m
+        member __.Return(x) = ok x
+        member __.ReturnFrom(x) = x
+        member __.Combine (a, b) = bind (protect b) a
+        member __.Delay f = protect f
+        member __.Run f = protect f ()
+        member __.TryWith (body, handler) = try body() with e -> handler e
+        member __.TryFinally (body, compensation) = try body() finally compensation()
+        member x.Using(d:#IDisposable, body) =
+            x.TryFinally ((fun () -> body d), fun () -> match d with null -> () | d -> d.Dispose())
+        member x.While (guard, body) =
+            if not (guard ()) then x.Zero()
+            else bind (fun () -> x.While(guard, body)) (body())
+
+    let trial = TrialBuilder()
+
+
+[<AutoOpen>]
+module private Details = 
+
+    let resourcePrefix = "mbrace"
+    let generateResourceName() = resourcePrefix + (Guid.NewGuid().ToString() |> Seq.take 8 |> Seq.toArray |> String)
+    let defaultExtendedProperties = dict [ "IsMBraceAsset", "true"]
+    let isMBraceAsset (extendedProperties:IDictionary<string, string>) = extendedProperties.ContainsKey "IsMBraceAsset"
+
+    //type PubSettings = XmlProvider< """<?xml version="1.0" encoding="utf-8"?><PublishData><PublishProfile SchemaVersion="2.0" PublishMethod="AzureServiceManagementAPI"><Subscription ServiceManagementUrl="https://management.core.windows.net" Id="de495429-2562-5242-81c8-54e236a5db4d" Name="Your First Subscription" ManagementCertificate="FIODSFSDIUS" /><Subscription ServiceManagementUrl="https://management.core.windows.net" Id="e156f021-460a-42fb-8a52-2878fbf83a25" Name="Second Subscription" ManagementCertificate="BLAH"/></PublishProfile></PublishData> """>
+    type Subscription = 
+        { Name : string; Id : string;  ManagementCertificate: string; ServiceManagementUrl:string }
+        static member LoadX(doc:XElement) = 
+            let name = doc.Attribute(XName.op_Implicit "Name").Value
+            let id = doc.Attribute(XName.op_Implicit "Id").Value
+            let mc = doc.Attribute(XName.op_Implicit "ManagementCertificate").Value
+            let sm = doc.Attribute(XName.op_Implicit "ServiceManagementUrl").Value
+            { Name = name;
+              Id = id;
+              ManagementCertificate = mc
+              ServiceManagementUrl = sm }
+
+    type PublishProfile = 
+        { Subscriptions: Subscription [] }
+        static member LoadX(doc:XElement) = 
+            let subs = [| for s in doc.Elements(XName.op_Implicit "Subscription") -> Subscription.LoadX s |]
+            { Subscriptions = subs }
+
+    type PubSettings = 
+        { PublishProfile: PublishProfile }
+        static member LoadX(doc:XDocument) = 
+                let publishDataXml = doc.Element(XName.op_Implicit "PublishData")
+                let publishProfileXml = publishDataXml.Element(XName.op_Implicit "PublishProfile")
+                { PublishProfile =  PublishProfile.LoadX publishProfileXml } 
+        static member Parse(xml:string) = PubSettings.LoadX (XDocument.Parse xml)
+    //PubSettings.Parse """<?xml version="1.0" encoding="utf-8"?><PublishData><PublishProfile SchemaVersion="2.0" PublishMethod="AzureServiceManagementAPI"><Subscription     ServiceManagementUrl="https://management.core.windows.net" Id="de495429-2562-5242-81c8-54e236a5db4d" Name="Your First Subscription" ManagementCertificate="FIODSFSDIUS" /><Subscription ServiceManagementUrl="https://management.core.windows.net" Id="e156f021-460a-42fb-8a52-2878fbf83a25" Name="Second Subscription" ManagementCertificate="BLAH"/></PublishProfile></PublishData> """
+
+
+    type AzureClient =
+        { Subscription : string
+          Credentials : CertificateCloudCredentials
+          Storage : StorageManagementClient
+          ServiceBus : ServiceBusManagementClient
+          Compute : ComputeManagementClient
+          Management : ManagementClient }
+        static member OfCredentials (subscription:Subscription) credentials =
+            { Subscription = subscription.Name
+              Credentials = credentials
+              Storage = new StorageManagementClient(credentials)
+              ServiceBus = new ServiceBusManagementClient(credentials)
+              Compute = new ComputeManagementClient(credentials)
+              Management = new ManagementClient(credentials) }
+
+    module Credentials =
+        let asCredentials (subscription:Subscription) =
+            new CertificateCloudCredentials(
+                subscription.Id,
+                new X509Certificate2(
+                    subscription.ManagementCertificate |> Convert.FromBase64String))
+
+        let getSubscriptions (pubSettingsFilePath:string) =
+            let pubSettings = PubSettings.Parse (File.ReadAllText pubSettingsFilePath)
+            pubSettings.PublishProfile.Subscriptions
+
+        let connectToAzure subscriptionOpt pubSettingsFilePath =
+          trial {
+            let subscriptions = getSubscriptions pubSettingsFilePath
+            if subscriptions.Length = 0 then 
+                return! fail (sprintf "no Azure subscriptions found in pubsettings file %s" pubSettingsFilePath)
+            let subscription = defaultArg subscriptionOpt subscriptions.[0].Name
+
+            match subscriptions |> Seq.tryFind(fun s -> s.Name = subscription) with 
+            | None -> return! fail (sprintf "couldn't find subscription %s in %s" subscription pubSettingsFilePath)
+            | Some sub -> return sub |> asCredentials |> AzureClient.OfCredentials sub 
+        }
+
+    module Infrastructure =
+        let listRegions (client:AzureClient) =
+            let requiredServices = [ "Compute"; "Storage" ]
+            let rolesForClient = set(client.Management.RoleSizes.List() |> Seq.map(fun r -> r.Name))
+            client.Management.Locations.List()
+            |> Seq.filter(fun location -> requiredServices |> List.forall(location.AvailableServices.Contains))
+            |> Seq.map(fun location ->
+                let rolesInLocation = set location.ComputeCapabilities.WebWorkerRoleSizes
+                location.Name, rolesForClient |> Set.intersect rolesInLocation |> Seq.toList)
+            |> Seq.toList
+
+
+    module Storage =
+        open Microsoft.WindowsAzure.Storage
+
+        let listStorageAccounts region (client:AzureClient) =
+            [ for account in client.Storage.StorageAccounts.List() do
+                let hasLocationData, storageAccountLocation = account.ExtendedProperties.TryGetValue "ResourceLocation"
+                if hasLocationData && storageAccountLocation = region then 
+                   yield account ]
+
+        let tryFindMBraceStorage region (client:AzureClient) =
+            client
+            |> listStorageAccounts region
+            |> List.filter(fun account -> account.ExtendedProperties |> isMBraceAsset)
+            |> List.map(fun account -> account.Name)
+            |> function [] -> None | h::_ -> Some h
+
+        let rec createMBraceStorageAccount region (client:AzureClient) =
+            trial {
+                let accountName = generateResourceName()
+                let availability = client.Storage.StorageAccounts.CheckNameAvailability accountName 
+                if not availability.IsAvailable then return! createMBraceStorageAccount region client
+                else
+                    let result = client.Storage.StorageAccounts.Create(StorageAccountCreateParameters(Name = accountName, AccountType = "Standard_LRS", Location = region, ExtendedProperties = defaultExtendedProperties))
+                    if result.Status = OperationStatus.Failed then 
+                        return! fail result.Error.Message
+                    else 
+                        do! info (sprintf "Created new storage account %s" accountName)
+                        return accountName }
+
+        let getConnectionString accountName (client:AzureClient) =
+            trial { 
+                let keys = client.Storage.StorageAccounts.GetKeys accountName
+                return sprintf """DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s""" accountName keys.PrimaryKey
+            }
+
+        let getDeploymentContainer connectionString =
+            let blobClient =
+                let account = CloudStorageAccount.Parse connectionString
+                account.CreateCloudBlobClient()
+            blobClient.GetContainerReference "deployments"
+
+        let configureMBraceStorageAccount connectionString = 
+            let container = getDeploymentContainer connectionString
+            container.CreateIfNotExists()
+
+        let getDefaultMBraceStorageAccountName region client =
+            trial {
+                match tryFindMBraceStorage region client with
+                | Some storage -> 
+                    do! info (sprintf "Reusing existing storage account %s" storage)
+                    return storage
+                | None -> 
+                    return! createMBraceStorageAccount region client
+            }
+
+        let getMBraceStorageConnectionString accountName (client:AzureClient) =
+            trial {
+                let! connectionString = getConnectionString accountName client 
+                configureMBraceStorageAccount connectionString |> ignore
+                return connectionString
+            }
+
+    module ServiceBus =
+        let rec waitUntilState checkState ns (client:AzureClient) =
+            let status = try (client.ServiceBus.Namespaces.Get ns).Namespace.Status with ex -> ""
+            if not (checkState status) then
+                Async.Sleep 2000 |> Async.RunSynchronously
+                waitUntilState checkState ns client
+
+        let rec createNamespace region (client:AzureClient) =
+            trial {
+                let namespaceName = generateResourceName()
+                do! info (sprintf "checking availability of service bus namespace %s" namespaceName)
+                let availability = client.ServiceBus.Namespaces.CheckAvailability namespaceName
+                if not availability.IsAvailable then 
+                    return! createNamespace region client
+                else
+                    do! info (sprintf "creating service bus namespace %s" namespaceName)
+                    let result = client.ServiceBus.Namespaces.Create(namespaceName, region) 
+
+                    client |> waitUntilState ((=) "Active") namespaceName
+
+                    if result.StatusCode <> Net.HttpStatusCode.OK then 
+                        return! fail(sprintf "Failed to create service bus: %O" result.StatusCode)
+                    else 
+                        do! info (sprintf "Created new default MBrace Service Bus namespace %s" namespaceName)
+                        return namespaceName }
+
+        let listNamespaces region (client:AzureClient) =
+            [ for account in client.ServiceBus.Namespaces.List() do 
+                 if account.Region = region then 
+                    yield account ]
+
+        let tryFindMBraceNamespace region (client:AzureClient) =
+            client
+            |> listNamespaces region
+            |> List.filter(fun ns -> ns.Name.StartsWith resourcePrefix)
+            |> List.map(fun ns -> ns.Name)
+            |> function [] -> None | h :: _ -> Some h
+
+        let getConnectionString namespaceName (client:AzureClient) =
+            trial {
+                let rule = client.ServiceBus.Namespaces.ListAuthorizationRules namespaceName |> Seq.find(fun rule -> rule.KeyName = "RootManageSharedAccessKey")
+                return sprintf """Endpoint=sb://%s.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=%s""" namespaceName rule.PrimaryKey
+            } 
+
+        let findOrCreateMBraceNamespace region client = 
+            trial {
+                match tryFindMBraceNamespace region client with
+                | Some ns -> 
+                    do! info (sprintf "Reusing existing Service Bus namespace %s" ns )
+                    return ns
+                | None -> return! createNamespace region client
+            }
+
+        let getDefaultMBraceNamespace region client =
+            trial {
+                let! ns = findOrCreateMBraceNamespace region client
+                let! connectionString = getConnectionString ns client
+                return ns, connectionString 
+            }
+
+        let deleteNamespace namespaceName (client:AzureClient) =
+            trial {
+                let _response = client.ServiceBus.Namespaces.Delete namespaceName
+                client |> waitUntilState ((<>) "Removing") namespaceName
+            }
+
+    module Clusters =
+        open System.IO
+
+        type Node = { Size : string; Status : string }
+        type ClusterDetails = {
+            Name : string
+            CreatedTime : DateTime
+            ServiceStatus : string
+            DeploymentStatus : string option
+            Nodes : Node list }
+
+        let validateClusterName (client:AzureClient) clusterName =
+            let result = client.Compute.HostedServices.CheckNameAvailability clusterName
+            if result.IsAvailable then ok clusterName
+            else fail result.Reason
+
+        let getClusterDetails clusterName (client:AzureClient) =
+            let service = client.Compute.HostedServices.GetDetailed clusterName
+            let storageConnectionString = service.Properties.ExtendedProperties.["StorageAccountConnectionString"]
+            let serviceBusConnectionString = service.Properties.ExtendedProperties.["ServiceBusConnectionString"]
+            let serviceBusNamespace = service.Properties.ExtendedProperties.["ServiceBusName"]
+            storageConnectionString, serviceBusConnectionString, serviceBusNamespace
+
+        let listRunningMBraceClusters (client:AzureClient) =
+            [ for service in client.Compute.HostedServices.List() do
+                 if service.Properties.ExtendedProperties |> isMBraceAsset then 
+                   let deployment =
+                        try client.Compute.Deployments.GetBySlot(service.ServiceName, DeploymentSlot.Production) |> Some
+                        with _ -> None
+                   let info = 
+                       { Name = service.ServiceName
+                         CreatedTime = service.Properties.DateCreated
+                         ServiceStatus = service.Properties.Status.ToString()
+                         DeploymentStatus = deployment |> Option.map(fun deployment -> deployment.Status.ToString())
+                         Nodes =
+                            deployment
+                            |> Option.map(fun deployment ->
+                                deployment.RoleInstances
+                                |> Seq.map(fun instance -> { Size = instance.InstanceSize; Status = instance.InstanceStatus })
+                                |> Seq.toList)
+                            |> defaultArg <| [] } 
+                   yield info  |> sprintf "%+A" ]
+
+        let buildMBraceConfig serviceName instances storageConnection serviceBusConnection =
+            sprintf """<?xml version="1.0" encoding="utf-8"?>
+    <ServiceConfiguration serviceName="%s" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceConfiguration" osFamily="4" osVersion="*" schemaVersion="2015-04.2.6">
+      <Role name="MBrace.Azure.WorkerRole">
+        <Instances count="%d" />
+        <ConfigurationSettings>
+          <Setting name="MBrace.StorageConnectionString" value="%s" />
+          <Setting name="MBrace.ServiceBusConnectionString" value="%s" />
+          <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="" />
+        </ConfigurationSettings>
+      </Role>
+    </ServiceConfiguration>""" serviceName instances storageConnection serviceBusConnection
+
+        let createMBraceCluster(clusterName, clusterLabel, region, packagePath, config, storageAccountName, storageConnectionString, serviceBusNamespace, serviceBusConnectionString) (client:AzureClient) =
+          trial {
+            let extendedProperties =
+                [ "StorageAccountName", storageAccountName
+                  "StorageAccountConnectionString", storageConnectionString
+                  "ServiceBusName", serviceBusNamespace
+                  "ServiceBusConnectionString", serviceBusConnectionString ]
+                @ (defaultExtendedProperties.Keys |> Seq.map(fun key -> key, defaultExtendedProperties.[key]) |> Seq.toList)
+                |> dict
+
+            do! info (sprintf "creating cloud service %s" clusterName)
+            client.Compute.HostedServices.Create(HostedServiceCreateParameters(Location = region, ServiceName = clusterName, ExtendedProperties = extendedProperties)) |> ignore
+
+            let container = Storage.getDeploymentContainer storageConnectionString
+            let packageBlob = packagePath |> Path.GetFileName |> container.GetBlockBlobReference
+            let blobSizesDoNotMatch() =
+                packageBlob.FetchAttributes()
+                packageBlob.Properties.Length <> FileInfo(packagePath).Length
+
+            if (not (packageBlob.Exists()) || blobSizesDoNotMatch()) then
+                do! info (sprintf "uploading package %s" packagePath)
+                packageBlob.UploadFromFile(packagePath, FileMode.Open)
+        
+            do! info (sprintf "scheduling cluster creation:\n  cluster %s\n  package uri %s\n  config %s" clusterName (packageBlob.Uri.ToString()) config)
+            let createOp = 
+                client.Compute.Deployments.BeginCreating(
+                    clusterName,
+                    DeploymentSlot.Production,
+                    DeploymentCreateParameters(
+                        Label = clusterLabel, 
+                        Name = clusterName,
+                        PackageUri = packageBlob.Uri,
+                        Configuration = config,
+                        StartDeployment = Nullable true,
+                        TreatWarningsAsError = Nullable true))
+
+            if createOp.StatusCode <> Net.HttpStatusCode.Accepted then 
+                return! fail "error: HTTP request for creation operation was not accepted"
+          }
+        let deleteMBraceCluster clusterName (client:AzureClient) =
+            trial {
+                let service = client.Compute.HostedServices.GetDetailed clusterName
+                if service.Properties.ExtendedProperties |> isMBraceAsset then
+                    do! info (sprintf "deleting cluster %s" clusterName)
+                    let deleteOp = client.Compute.Deployments.DeleteByName(clusterName, clusterName, true)
+                    if deleteOp.Status <> OperationStatus.Succeeded then return! fail deleteOp.Error.Message
+                    let deleteOp = client.Compute.HostedServices.Delete clusterName
+                    if deleteOp.StatusCode <> Net.HttpStatusCode.OK then return! fail(deleteOp.StatusCode.ToString()) 
+                else
+                    do! info (sprintf "No MBrace cluster called %s found" clusterName)
+            }
+
+
+
+type Regions() = 
+    static member South_Central_US = "South Central US"
+    static member West_US = "West US"
+    static member Central_US = "Central US"
+    static member East_US = "East US"
+    static member East_US_2 = "East US 2"
+    static member North_Europe = "North Europe"
+    static member West_Europe = "West Europe"
+    static member Southeast_Asia = "Southeast Asia"
+    static member East_Asia = "East Asia"
+
+
+
+type VMSizes() = 
+     static member A10 = "A10"
+     static member A11 = "A11"
+     static member A5 = "A5"
+     static member A6 = "A6"
+     static member A7 = "A7"
+     static member A8 = "A8"
+     static member A9 = "A9"
+     static member A4 = "ExtraLarge" // A4
+     static member A0 = "ExtraSmall" // A0
+     static member A3 = "Large" // A3
+     static member A2 = "Medium" // A2
+     static member A1 = "Small" // A1
+     static member ExtraLarge = "ExtraLarge" // A4
+     static member Large = "Large" // A3
+     static member Medium = "Medium" // A2
+     static member Small = "Small" // A1
+     static member ExtraSmall = "ExtraSmall" // A0
+     static member Standard_D1 = "Standard_D1"
+     static member Standard_D11 = "Standard_D11"
+     static member Standard_D11_v2 = "Standard_D11_v2"
+     static member Standard_D12 = "Standard_D12"
+     static member Standard_D12_v2 = "Standard_D12_v2"
+     static member Standard_D13 = "Standard_D13"
+     static member Standard_D13_v2 = "Standard_D13_v2"
+     static member Standard_D14 = "Standard_D14"
+     static member Standard_D14_v2 = "Standard_D14_v2"
+     static member Standard_D1_v2 = "Standard_D1_v2"
+     static member Standard_D2 = "Standard_D2"
+     static member Standard_D2_v2 = "Standard_D2_v2"
+     static member Standard_D3 = "Standard_D3"
+     static member Standard_D3_v2 = "Standard_D3_v2";
+     static member Standard_D4 = "Standard_D4"
+     static member Standard_D4_v2 = "Standard_D4_v2"
+     static member Standard_D5_v2 = "Standard_D5_v2"
+
+type Management() = 
+    static let mbracePackageVersion = System.AssemblyVersionInformation.Version
+
+    static member CreateCluster(pubSettingsFile, region, ?ClusterName, ?Subscription, ?MBraceVersion, ?VMCount, ?StorageAccount, ?VMSize, ?CloudServicePackage, ?ClusterLabel) =
+       trial { 
+           let vmSize = defaultArg VMSize VMSizes.Large
+           do! info (sprintf "using vm size %s" vmSize)
+           let! packagePath = 
+             trial { 
+               match CloudServicePackage with 
+               | Some uriOrPath when System.Uri(uriOrPath).IsFile ->  
+                   let path = System.Uri(uriOrPath).LocalPath
+                   do! info (sprintf "using cloud service package from %s" path)
+                   return path
+               | _ -> 
+                   let mbraceVersion = defaultArg MBraceVersion mbracePackageVersion
+                   do! info (sprintf "using MBrace version %s" mbraceVersion)
+                   let uri = defaultArg CloudServicePackage (sprintf "https://github.com/mbraceproject/MBrace.Azure/releases/download/%s/MBrace.Azure.CloudService-%s.cspkg" mbraceVersion vmSize)
+                   use wc = new System.Net.WebClient() 
+                   let tmp = System.IO.Path.GetTempFileName() 
+                   do! info (sprintf "downloading cloud service package from %s" uri)
+                   wc.DownloadFile(uri, tmp)
+                   return tmp
+            }
+           let! client = Credentials.connectToAzure Subscription pubSettingsFile 
+           let clusterName = defaultArg ClusterName (generateResourceName())
+           do! info (sprintf "using cluster name %s" clusterName)
+           let! storageAccountName = 
+             trial {
+               match StorageAccount with 
+               | None -> return! Storage.getDefaultMBraceStorageAccountName region client
+               | Some s -> return s
+             }
+           let! storageConnectionString = client |> Storage.getMBraceStorageConnectionString storageAccountName 
+           do! info (sprintf "using storage account name %s" storageAccountName)
+           do! info (sprintf "using storage connection string %s..." storageConnectionString.[0..20])
+           let! serviceBusNamespace, serviceBusConnectionString = client |> ServiceBus.getDefaultMBraceNamespace region
+           do! info (sprintf "using service bus namespace %s" serviceBusNamespace)
+           do! info (sprintf "using service bus connection string %s..." serviceBusConnectionString.[0..20])
+
+           let numInstances = defaultArg VMCount 2
+           let config = Clusters.buildMBraceConfig clusterName numInstances storageConnectionString serviceBusConnectionString
+    
+           let clusterLabel = defaultArg ClusterLabel (sprintf "MBrace cluster %s, MBrace.Azure version %s"  clusterName mbracePackageVersion)
+           do! Clusters.createMBraceCluster(clusterName, clusterLabel, region, packagePath, config, storageAccountName, storageConnectionString, serviceBusNamespace, serviceBusConnectionString) client
+           return clusterName
+
+        }  |> Trial.returnOrFail
+
+    static member DeleteCluster(pubSettingsFile, clusterName, ?Subscription) =
+       trial { 
+           let! client = Credentials.connectToAzure Subscription pubSettingsFile 
+           return! Clusters.deleteMBraceCluster clusterName client
+
+        }  |> Trial.returnOrFail
+
+    static member GetClusters(pubSettingsFile, ?Subscription) =
+       trial { 
+           let! client = Credentials.connectToAzure Subscription pubSettingsFile 
+           let response = Clusters.listRunningMBraceClusters client
+           return response
+
+        }  |> Trial.returnOrFail
+
+

--- a/src/MBrace.Azure/Management.fsi
+++ b/src/MBrace.Azure/Management.fsi
@@ -67,7 +67,7 @@ type Management =
     /// <param name="StorageAccount">The name of the storage ccount to use. Defaults to reusing a suitable existing account if available, otherwise creates a new one.</param>
     /// <param name="CloudServicePackage">An explicit cloud service package to use.</param>
     /// <param name="ClusterLabel">The label to give the deployment of the cloud service.</param>
-    static member CreateCluster : pubSettingsFile : string * region : string * ?ClusterName : string *  ?Subscription : string *  ?MBraceVersion : string * ?VMCount: int * ?StorageAccount: string * ?VMSize: string * ?CloudServicePackage : string * ?ClusterLabel : string -> string
+    static member CreateCluster : pubSettingsFile : string * region : string * ?ClusterName : string *  ?Subscription : string *  ?MBraceVersion : string * ?VMCount: int * ?StorageAccount: string * ?VMSize: string * ?CloudServicePackage : string * ?ClusterLabel : string -> Configuration
 
     /// <summary>Delete the given cluster from the subscription from the pubsettings file</summary>
     /// <param name="pubSettingsFile">The path to the pubsettings file. Download from https://manage.windowsazure.com/publishsettings</param>

--- a/src/MBrace.Azure/Management.fsi
+++ b/src/MBrace.Azure/Management.fsi
@@ -1,0 +1,83 @@
+﻿
+namespace MBrace.Azure
+
+
+[<Class>]
+/// The regions in which Azure clusters can be created
+type Regions = 
+    static member South_Central_US : string
+    static member West_US  : string
+    static member Central_US  : string
+    static member East_US  : string
+    static member East_US_2  : string
+    static member North_Europe  : string
+    static member West_Europe  : string
+    static member Southeast_Asia  : string
+    static member East_Asia  : string
+
+[<Class>]
+/// The VM sizes for Azure clusters 
+type VMSizes = 
+     static member A10  : string
+     static member A11  : string
+     static member A5  : string
+     static member A6  : string
+     static member A7  : string
+     static member A8  : string
+     static member A9  : string
+     static member A4  : string
+     static member A0  : string
+     static member A3  : string
+     static member A2  : string
+     static member A1  : string
+     static member ExtraLarge  : string
+     static member Large  : string
+     static member Medium  : string
+     static member Small  : string
+     static member ExtraSmall  : string
+     static member Standard_D1  : string
+     static member Standard_D11  : string
+     static member Standard_D11_v2  : string
+     static member Standard_D12  : string
+     static member Standard_D12_v2  : string
+     static member Standard_D13  : string
+     static member Standard_D13_v2  : string
+     static member Standard_D14  : string
+     static member Standard_D14_v2  : string
+     static member Standard_D1_v2  : string
+     static member Standard_D2  : string
+     static member Standard_D2_v2  : string
+     static member Standard_D3  : string
+     static member Standard_D3_v2  : string
+     static member Standard_D4  : string
+     static member Standard_D4_v2  : string
+     static member Standard_D5_v2  : string
+
+[<Class>]
+type Management = 
+
+    /// <summary>Provision an MBrace cluster in the subscription from the pubsettings file</summary>
+    /// <param name="pubSettingsFile">The path to the pubsettings file. Download from https://manage.windowsazure.com/publishsettings</param>
+    /// <param name="region">The Azure region in which to create the cluster. Choose from Regions.*</param>
+    /// <param name="ClusterName">The name of the cluster</param>
+    /// <param name="Subscription">The subscription to use</param>
+    /// <param name="MBraceVersion">The MBrace software version id to use. Ignored if using an explicit package.</param>
+    /// <param name="VMCount">The number of virtual machines to allocate in the cluster.</param>
+    /// <param name="VMSize">The size of virtual machines to allocate in the cluster. Use one of VMSizes.*</param>
+    /// <param name="StorageAccount">The name of the storage ccount to use. Defaults to reusing a suitable existing account if available, otherwise creates a new one.</param>
+    /// <param name="CloudServicePackage">An explicit cloud service package to use.</param>
+    /// <param name="ClusterLabel">The label to give the deployment of the cloud service.</param>
+    static member CreateCluster : pubSettingsFile : string * region : string * ?ClusterName : string *  ?Subscription : string *  ?MBraceVersion : string * ?VMCount: int * ?StorageAccount: string * ?VMSize: string * ?CloudServicePackage : string * ?ClusterLabel : string -> string
+
+    /// <summary>Delete the given cluster from the subscription from the pubsettings file</summary>
+    /// <param name="pubSettingsFile">The path to the pubsettings file. Download from https://manage.windowsazure.com/publishsettings</param>
+    /// <param name="clusterName">The name of the cluster</param>
+    /// <param name="Subscription">The subscription to use</param>
+    static member DeleteCluster : pubSettingsFile : string * clusterName : string * ?Subscription : string -> unit
+
+    /// <summaryGet a string representation of each of the MBrace clusters in the subscription from the pubsettings file</summary>
+    /// <param name="pubSettingsFile">The path to the pubsettings file. Download from https://manage.windowsazure.com/publishsettings</param>
+    /// <param name="clusterName">The name of the cluster</param>
+    /// <param name="Subscription">The subscription to use</param>
+    static member GetClusters : pubSettingsFile : string * ?Subscription : string  -> string list
+

--- a/src/MBrace.Azure/paket.references
+++ b/src/MBrace.Azure/paket.references
@@ -7,3 +7,6 @@ Vagabond
 MBrace.Runtime
 WindowsAzure.ServiceBus
 WindowsAzure.Storage
+Microsoft.WindowsAzure.Management.Libraries
+Microsoft.WindowsAzure.Management.ServiceBus
+Microsoft.Bcl.Async

--- a/src/MBrace.Azure/paket.references
+++ b/src/MBrace.Azure/paket.references
@@ -9,4 +9,4 @@ WindowsAzure.ServiceBus
 WindowsAzure.Storage
 Microsoft.WindowsAzure.Management.Libraries
 Microsoft.WindowsAzure.Management.ServiceBus
-Microsoft.Bcl.Async
+

--- a/src/MBrace.Azure/paket.template
+++ b/src/MBrace.Azure/paket.template
@@ -36,6 +36,15 @@ files
 	../../bin/Microsoft.ServiceBus.dll ==> tools
 	../../bin/Microsoft.WindowsAzure.Configuration.dll ==> tools
 	../../bin/Microsoft.WindowsAzure.Storage.dll ==> tools
+	../../bin/Hyak.Common.dll ==> tools
+	../../bin/Microsoft.Azure.Common.dll ==> tools
+	../../bin/Microsoft.Azure.Common.NetFramework.dll ==> tools
+	../../bin/Microsoft.WindowsAzure.Management.dll ==> tools
+	../../bin/Microsoft.WindowsAzure.Management.Compute.dll ==> tools
+	../../bin/Microsoft.WindowsAzure.Management.Storage.dll ==> tools
+	../../bin/Microsoft.WindowsAzure.Management.ServiceBus.dll ==> tools
+	../../bin/Microsoft.WindowsAzure.Management.ServiceBus.dll ==> tools
+    ../../bin/Microsoft.Threading.Tasks.dll ==> tools
     ../../bin/MBrace.Core.dll ==> tools
 	../../bin/MBrace.Core.pdb ==> tools
 	../../bin/MBrace.Core.xml ==> tools

--- a/tests/MBrace.Azure.Tests/MBrace.Azure.Tests.fsproj
+++ b/tests/MBrace.Azure.Tests/MBrace.Azure.Tests.fsproj
@@ -437,24 +437,6 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json">
-          <HintPath>..\..\packages\Newtonsoft.Json\lib\net35\Newtonsoft.Json.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0')">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json">
-          <HintPath>..\..\packages\Newtonsoft.Json\lib\net20\Newtonsoft.Json.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
         <Reference Include="Newtonsoft.Json">
@@ -473,16 +455,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile259')">
-      <ItemGroup>
-        <Reference Include="Newtonsoft.Json">
-          <HintPath>..\..\packages\Newtonsoft.Json\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkProfile) == 'Profile5') Or ($(TargetFrameworkProfile) == 'Profile6') Or ($(TargetFrameworkProfile) == 'Profile14') Or ($(TargetFrameworkProfile) == 'Profile19') Or ($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile37') Or ($(TargetFrameworkProfile) == 'Profile42') Or ($(TargetFrameworkProfile) == 'Profile47') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile92') Or ($(TargetFrameworkProfile) == 'Profile102') Or ($(TargetFrameworkProfile) == 'Profile136') Or ($(TargetFrameworkProfile) == 'Profile147') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile158') Or ($(TargetFrameworkProfile) == 'Profile225') Or ($(TargetFrameworkProfile) == 'Profile240') Or ($(TargetFrameworkProfile) == 'Profile255') Or ($(TargetFrameworkProfile) == 'Profile328') Or ($(TargetFrameworkProfile) == 'Profile336') Or ($(TargetFrameworkProfile) == 'Profile344')">
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And $(TargetFrameworkVersion) == 'v8.0'">
       <ItemGroup>
         <Reference Include="Newtonsoft.Json">
           <HintPath>..\..\packages\Newtonsoft.Json\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>

--- a/tests/MBrace.Azure.Tests/app.config
+++ b/tests/MBrace.Azure.Tests/app.config
@@ -67,6 +67,86 @@
     <assemblyIdentity name="Mono.Cecil" publicKeyToken="0738eb9f132ed756" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="0.9.6.0" />
   </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Hyak.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Azure.Common.NetFramework" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Azure.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Threading.Tasks.Extensions.Desktop" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.168.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Threading.Tasks.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.12.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.12.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="System.Net.Http.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.2.29.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.2.29.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Common.NetFramework" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Compute" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="12.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.MediaServices" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Monitoring" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Network" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="7.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Scheduler" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="6.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="0.9.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Sql" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="5.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="5.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Microsoft.WindowsAzure.Management.WebSites" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.0.0.0" />
+  </dependentAssembly>
 </assemblyBinding></runtime>
 <system.serviceModel>
     <extensions>


### PR DESCRIPTION
This adds a provisioning API to MBrace.Azure

When incorporated it will allow

    let pubSettingsFile = @"...Foo-credentials.publishsettings"
    
    Management.CreateCluster(pubSettingsFile,Regions.North_Europe)

There are various explicit options such as explicitly specifying the VM size etc.

There is one thing left to do after this: by default the compiled cloud service package will be drawn from 

    https://github.com/mbraceproject/MBrace.Azure/releases/download/VERSION/MBrace.Azure.CloudService-VMSIZE.cspkg

so we must adjust the FAKE Release build of MBrace.Azure to build a range of cloud service packages with different VM Size specifications and publish those as part of the release.

