### PR TITLE
No longer download cspkg from GitHub only to upload it again.

### DIFF
--- a/src/MBrace.Azure.Management/Compute.fs
+++ b/src/MBrace.Azure.Management/Compute.fs
@@ -240,8 +240,8 @@ module internal Compute =
             return packageBlob.Uri
         | Local file -> 
             let blobName =
-                let uriHash = getTextHash (file.Name)
-                sprintf "%s-%s" file.Name uriHash
+                let fileHash = getFileHash (file.FullName)
+                sprintf "%s-%s-%d" file.Name fileHash file.Length
             let packageBlob = container.GetBlockBlobReference blobName
             let! blobExists = packageBlob.ExistsAsync() |> Async.AwaitTaskCorrect
             if not blobExists then


### PR DESCRIPTION
We now use Azure's native CopyFromBlob API to import a blob from any HTTP uri - so this works for both the MBrace GitHub and for public URIs. This provides a perform boost when creating clusters, particularly if the machine creating the cluster has low bandwidth.