### PR TITLE
Resize operations now throw if core count limit exceed.

### DIFF
--- a/src/MBrace.Azure.Management/Compute.fs
+++ b/src/MBrace.Azure.Management/Compute.fs
@@ -295,8 +295,8 @@ module internal Compute =
         | Some di ->
             let newConfiguration = buildMBraceConfig serviceName newCount true di.StorageAccount di.ServiceBusAccount
             let changeParams = new DeploymentChangeConfigurationParameters(Configuration = newConfiguration)
-            let! changeOp = client.Compute.Deployments.BeginChangingConfigurationByNameAsync(serviceName, serviceName, changeParams) |> Async.AwaitTaskCorrect
-            if changeOp.StatusCode <> Net.HttpStatusCode.Accepted then
+            let! changeOp = client.Compute.Deployments.ChangeConfigurationByNameAsync(serviceName, serviceName, changeParams) |> Async.AwaitTaskCorrect
+            if changeOp.StatusCode <> Net.HttpStatusCode.OK then
                 return invalidOp <| sprintf "error: HTTP request for change operation %A was not accepted (status code: %O)" serviceName changeOp.StatusCode
     }
 


### PR DESCRIPTION
Fixes #135. The change here does not block the caller for long (< 1 second) before validation is completed (unlike Provision which can take ~15 seconds) and therefore is a simple change. If you exceed core count limit you'll now get a proper exception throw immediately.