### PR TITLE
Retrieve app settings from environment variables for the standalone worker

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -23,6 +23,7 @@ nuget Microsoft.WindowsAzure.ConfigurationManager
 nuget Microsoft.Bcl.Async ~> 1.0
 nuget System.Runtime.Loader
 nuget System.Reflection.Metadata
+github isaacabraham/azure-fsharp-helpers src/configuration.fs
 
 group Build
   source https://www.nuget.org/api/v2

--- a/paket.lock
+++ b/paket.lock
@@ -125,7 +125,9 @@ NUGET
       Microsoft.Data.OData (>= 5.6.4)
       Microsoft.Data.Services.Client (>= 5.6.4)
       Newtonsoft.Json (>= 6.0.8)
-
+GITHUB
+  remote: isaacabraham/azure-fsharp-helpers
+    src/configuration.fs (750f353438da7c69fdc62935d30faeda2c42eac1)
 GROUP Build
 NUGET
   remote: https://www.nuget.org/api/v2
@@ -142,4 +144,4 @@ NUGET
 GITHUB
   remote: fsharp/FAKE
     modules/Octokit/Octokit.fsx (c56456abac6b744c3bb95b217687db19fd19b367)
-      Octokit (>= 0.20)
+      Octokit

--- a/src/MBrace.Azure.StandaloneWorker/MBrace.Azure.StandaloneWorker.fsproj
+++ b/src/MBrace.Azure.StandaloneWorker/MBrace.Azure.StandaloneWorker.fsproj
@@ -57,6 +57,10 @@
   </Choose>
   <Import Project="$(FSharpTargetsPath)" />
   <ItemGroup>
+    <Compile Include="..\..\paket-files\isaacabraham\azure-fsharp-helpers\src\configuration.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/configuration.fs</Link>
+    </Compile>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="main.fs" />
     <None Include="App.config" />
@@ -68,6 +72,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Numerics" />

--- a/src/MBrace.Azure.StandaloneWorker/main.fs
+++ b/src/MBrace.Azure.StandaloneWorker/main.fs
@@ -1,4 +1,6 @@
 ﻿module internal MBrace.Azure.StandaloneWorker
 
 [<EntryPoint>]
-let main (args : string []) = MBrace.Azure.Service.StandaloneWorker.main args
+let main (args : string []) =
+    System.Configuration.Azure.applyAzureEnvironmentToConfigurationManager ()
+    MBrace.Azure.Service.StandaloneWorker.main args

--- a/src/MBrace.Azure.StandaloneWorker/paket.references
+++ b/src/MBrace.Azure.StandaloneWorker/paket.references
@@ -6,3 +6,4 @@ System.Spatial
 Vagabond
 WindowsAzure.ServiceBus
 WindowsAzure.Storage
+File:configuration.fs


### PR DESCRIPTION
Azure webjobs are the modern approach to hosting long running processes within Azure. Configuration in Azure webjobs is provided by environment variables prefixed with certain keywords. This PR introduces a dependency on @isaacabraham's Azure helper for configuration which loads the environment variables into the configuration manager, ensuring that the app settings are able to be read by Argu. This change only affects the StandaloneWorker project and would then allow it to be easily deployed as an Azure webjob.